### PR TITLE
Ensure consistent array instance type

### DIFF
--- a/Bonsai.Sgen/Program.cs
+++ b/Bonsai.Sgen/Program.cs
@@ -64,6 +64,7 @@ namespace Bonsai.Sgen
                     GenerateJsonMethods = true,
                     JsonLibrary = CSharpJsonLibrary.NewtonsoftJson,
                     SerializerLibraries = serializerLibrary,
+                    ArrayInstanceType = "System.Collections.Generic.List",
                     ArrayBaseType = "System.Collections.Generic.List",
                     ArrayType = "System.Collections.Generic.List"
                 };

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://bonsai-rx.org/sgen</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bonsai-rx/sgen.git</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <VersionSuffix>build230726</VersionSuffix>
+    <VersionSuffix>build231006</VersionSuffix>
     <IncludeSymbols>true</IncludeSymbols>
     <RepositoryType>git</RepositoryType>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
This PR fixes the case of required collection types where the instance of the array was set to `Collection` instead of `List` to match the property and field types.

Fixes #3 