### PR TITLE
Add unit test project

### DIFF
--- a/Bonsai.Sgen.Tests/Bonsai.Sgen.Tests.csproj
+++ b/Bonsai.Sgen.Tests/Bonsai.Sgen.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bonsai.Sgen\Bonsai.Sgen.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Bonsai.Sgen.Tests/EnumGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/EnumGenerationTests.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NJsonSchema;
+using NJsonSchema.Generation;
 
 namespace Bonsai.Sgen.Tests
 {
@@ -26,9 +27,10 @@ namespace Bonsai.Sgen.Tests
         [TestMethod]
         public void GenerateIntegerEnum_SerializerAnnotationsUseIntegerValues()
         {
-            var schema = JsonSchema.FromType<Foo>();
+            var schema = JsonSchema.FromType<Foo>(new JsonSchemaGeneratorSettings { GenerateEnumMappingDescription = true });
             var generator = TestHelper.CreateGenerator(schema);
             var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("/// 0 = A"));
             Assert.IsTrue(code.Contains("EnumMemberAttribute(Value=\"0\")"));
             Assert.IsTrue(code.Contains("YamlMemberAttribute(Alias=\"0\")"));
         }

--- a/Bonsai.Sgen.Tests/EnumGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/EnumGenerationTests.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using NJsonSchema;
+
+namespace Bonsai.Sgen.Tests
+{
+    [TestClass]
+    public class EnumGenerationTests
+    {
+        public class Foo
+        {
+            public Bar Bar { get; set; }
+
+            [JsonConverter(typeof(StringEnumConverter))]
+            public Bar Bar2 { get; set; }
+        }
+
+        public enum Bar
+        {
+            A = 0,
+            B = 5,
+            C = 6
+        }
+
+        [TestMethod]
+        public void GenerateIntegerEnum_SerializerAnnotationsUseIntegerValues()
+        {
+            var schema = JsonSchema.FromType<Foo>();
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("EnumMemberAttribute(Value=\"0\")"));
+            Assert.IsTrue(code.Contains("YamlMemberAttribute(Alias=\"0\")"));
+        }
+
+        [TestMethod]
+        public void GenerateStringEnum_SerializerAnnotationsUseStringValues()
+        {
+            var schema = JsonSchema.FromType<Foo>();
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("EnumMemberAttribute(Value=\"A\")"));
+            Assert.IsTrue(code.Contains("YamlMemberAttribute(Alias=\"A\")"));
+        }
+    }
+}

--- a/Bonsai.Sgen.Tests/TestHelper.cs
+++ b/Bonsai.Sgen.Tests/TestHelper.cs
@@ -1,0 +1,20 @@
+﻿using NJsonSchema;
+
+namespace Bonsai.Sgen.Tests
+{
+    static class TestHelper
+    {
+        public static CSharpCodeDomGenerator CreateGenerator(
+            JsonSchema schema,
+            SerializerLibraries serializerLibraries = SerializerLibraries.YamlDotNet | SerializerLibraries.NewtonsoftJson)
+        {
+            var settings = new CSharpCodeDomGeneratorSettings
+            {
+                Namespace = nameof(TestHelper),
+                SerializerLibraries = serializerLibraries
+            };
+
+            return new CSharpCodeDomGenerator(schema, settings);
+        }
+    }
+}

--- a/Bonsai.Sgen.sln
+++ b/Bonsai.Sgen.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonsai.Sgen.Tests", "Bonsai.Sgen.Tests\Bonsai.Sgen.Tests.csproj", "{DF485243-376F-4632-A637-D489B799F59A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{871C451B-BCFC-4DBA-B65E-35BB52D8F379}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{871C451B-BCFC-4DBA-B65E-35BB52D8F379}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{871C451B-BCFC-4DBA-B65E-35BB52D8F379}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF485243-376F-4632-A637-D489B799F59A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF485243-376F-4632-A637-D489B799F59A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF485243-376F-4632-A637-D489B799F59A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF485243-376F-4632-A637-D489B799F59A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Bonsai.Sgen/Bonsai.Sgen.csproj
+++ b/Bonsai.Sgen/Bonsai.Sgen.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <PackageId>Bonsai.Sgen</PackageId>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Bonsai.Sgen/CSharpCodeDomGeneratorSettings.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGeneratorSettings.cs
@@ -4,6 +4,16 @@ namespace Bonsai.Sgen
 {
     internal class CSharpCodeDomGeneratorSettings : CSharpGeneratorSettings
     {
+        public CSharpCodeDomGeneratorSettings()
+        {
+            GenerateDataAnnotations = false;
+            GenerateJsonMethods = true;
+            JsonLibrary = CSharpJsonLibrary.NewtonsoftJson;
+            ArrayInstanceType = "System.Collections.Generic.List";
+            ArrayBaseType = "System.Collections.Generic.List";
+            ArrayType = "System.Collections.Generic.List";
+        }
+
         public SerializerLibraries SerializerLibraries { get; set; }
     }
 }

--- a/Bonsai.Sgen/Program.cs
+++ b/Bonsai.Sgen/Program.cs
@@ -60,13 +60,7 @@ namespace Bonsai.Sgen
                 var settings = new CSharpCodeDomGeneratorSettings
                 {
                     Namespace = generatorNamespace,
-                    GenerateDataAnnotations = false,
-                    GenerateJsonMethods = true,
-                    JsonLibrary = CSharpJsonLibrary.NewtonsoftJson,
-                    SerializerLibraries = serializerLibraries,
-                    ArrayInstanceType = "System.Collections.Generic.List",
-                    ArrayBaseType = "System.Collections.Generic.List",
-                    ArrayType = "System.Collections.Generic.List"
+                    SerializerLibraries = serializerLibraries
                 };
 
                 var generator = new CSharpCodeDomGenerator(schema, settings);

--- a/Bonsai.Sgen/Program.cs
+++ b/Bonsai.Sgen/Program.cs
@@ -22,7 +22,7 @@ namespace Bonsai.Sgen
             var outputPath = new Option<string>(
                 name: "--output",
                 description: "Specifies the name of the file containing the generated code.");
-            var serializerLibrary = new Option<SerializerLibraries>(
+            var serializerLibraries = new Option<SerializerLibraries>(
                 name: "--serializer",
                 description: "Specifies the serializer data annotations to include in the generated classes.",
                 parseArgument: result =>
@@ -34,16 +34,16 @@ namespace Bonsai.Sgen
                     }
                     return serializers;
                 }) { AllowMultipleArgumentsPerToken = true, Arity = ArgumentArity.OneOrMore };
-            serializerLibrary.FromAmong(typeof(SerializerLibraries).GetEnumNames());
-            serializerLibrary.SetDefaultValue(SerializerLibraries.YamlDotNet);
+            serializerLibraries.FromAmong(typeof(SerializerLibraries).GetEnumNames());
+            serializerLibraries.SetDefaultValue(SerializerLibraries.YamlDotNet);
             
             var rootCommand = new RootCommand("Tool for automatically generating YML serialization classes from schema files.");
             rootCommand.AddOption(schemaPath);
             rootCommand.AddOption(generatorNamespace);
             rootCommand.AddOption(generatorTypeName);
             rootCommand.AddOption(outputPath);
-            rootCommand.AddOption(serializerLibrary);
-            rootCommand.SetHandler(async (filePath, generatorNamespace, generatorTypeName, outputFilePath, serializerLibrary) =>
+            rootCommand.AddOption(serializerLibraries);
+            rootCommand.SetHandler(async (filePath, generatorNamespace, generatorTypeName, outputFilePath, serializerLibraries) =>
             {
                 var schema = await JsonSchema.FromFileAsync(filePath.FullName);
                 if (string.IsNullOrEmpty(generatorTypeName))
@@ -63,7 +63,7 @@ namespace Bonsai.Sgen
                     GenerateDataAnnotations = false,
                     GenerateJsonMethods = true,
                     JsonLibrary = CSharpJsonLibrary.NewtonsoftJson,
-                    SerializerLibraries = serializerLibrary,
+                    SerializerLibraries = serializerLibraries,
                     ArrayInstanceType = "System.Collections.Generic.List",
                     ArrayBaseType = "System.Collections.Generic.List",
                     ArrayType = "System.Collections.Generic.List"
@@ -78,7 +78,7 @@ namespace Bonsai.Sgen
 
                 Console.WriteLine($"Writing schema classes to {outputFilePath}...");
                 File.WriteAllText(outputFilePath, code);
-            }, schemaPath, generatorNamespace, generatorTypeName, outputPath, serializerLibrary);
+            }, schemaPath, generatorNamespace, generatorTypeName, outputPath, serializerLibraries);
             await rootCommand.InvokeAsync(args);
         }
     }

--- a/Bonsai.Sgen/Properties/AssemblyInfo.cs
+++ b/Bonsai.Sgen/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Bonsai.Sgen.Tests")]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <PropertyGroup>
     <Authors>Bonsai</Authors>
-    <PackageId>Bonsai.Sgen</PackageId>
     <PackageIcon>icon.png</PackageIcon>
     <Description>A tool for automatically generating YML serialization classes from schema files.</Description>
     <ToolCommandName>bonsai.sgen</ToolCommandName>
@@ -11,7 +10,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © Bonsai Foundation CIC 2023</Copyright>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <PackageProjectUrl>https://bonsai-rx.org/sgen</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bonsai-rx/sgen.git</RepositoryUrl>
@@ -23,7 +22,7 @@
     <Features>strict</Features>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <Content Include="..\LICENSE" PackagePath="/" />
     <Content Include="..\icon.png" PackagePath="/" />
     <Content Include="..\README.md" PackagePath="/" />


### PR DESCRIPTION
A unit test project is added so we can track regressions and evaluate desired results when implementing more complex code generator features. Minor code refactoring was made to make testing easier and more consistent, and a simple enum generation regression test was added as example.