### PR TITLE
Add support for inherited class properties

### DIFF
--- a/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -34,6 +34,7 @@ namespace Bonsai.Sgen
         public string Render()
         {
             var type = new CodeTypeDeclaration(Model.ClassName) { IsPartial = true };
+            if (Model.IsAbstract) type.TypeAttributes |= System.Reflection.TypeAttributes.Abstract;
             if (Model.BaseClass != null)
             {
                 type.BaseTypes.Add(Model.BaseClassName);
@@ -126,7 +127,7 @@ namespace Bonsai.Sgen
                 type.Members.Add(propertyDeclaration);
             }
 
-            if (Model.GenerateJsonMethods)
+            if (Model.GenerateJsonMethods && !Model.IsAbstract)
             {
                 var processMethod = new CodeMemberMethod
                 {

--- a/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -34,6 +34,11 @@ namespace Bonsai.Sgen
         public string Render()
         {
             var type = new CodeTypeDeclaration(Model.ClassName) { IsPartial = true };
+            if (Model.BaseClass != null)
+            {
+                type.BaseTypes.Add(Model.BaseClassName);
+            }
+
             if (Model.HasDescription)
             {
                 type.Comments.Add(new CodeCommentStatement("<summary>", docComment: true));
@@ -133,7 +138,7 @@ namespace Bonsai.Sgen
                     }
                 };
                 var propertyAssignments = new StringBuilder();
-                foreach (var property in Model.Properties)
+                foreach (var property in Model.AllProperties)
                 {
                     if (propertyAssignments.Length > 0)
                     {


### PR DESCRIPTION
This PR improves class generation for schemas declaring inherited properties from subschemas, e.g. using the `allOf` keyword. Essentially any pattern recognized by NJsonSchema to give rise to a base class inheritance relationship will be captured. A protected copy constructor method is generated for each type, to allow initialization of base class fields.

Support for abstract base classes is also provided using extensions such as the `x-abstract` properties, which are natively supported by NJsonSchema. In this case the combinator constructor methods are removed from the class, since it is never possible to create an instance from an abstract class.