### PR TITLE
Add support for JSON type discriminators

### DIFF
--- a/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema;
+using System.Threading.Tasks;
+
+namespace Bonsai.Sgen.Tests
+{
+    [TestClass]
+    public class DiscriminatorGenerationTests
+    {
+        [TestMethod]
+        public async Task GenerateDiscriminatorSchema_SerializerAnnotationsDeclareKnownTypes()
+        {
+            var schema = await JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""type"": ""object"",
+    ""title"": ""Container"",
+    ""additionalProperties"": false,
+    ""properties"": {
+      ""Animal"": {
+        ""oneOf"": [
+          {
+            ""$ref"": ""#/definitions/Animal""
+          },
+          {
+            ""type"": ""null""
+          }
+        ]
+      }
+    },
+    ""definitions"": {
+      ""Dog"": {
+        ""type"": ""object"",
+        ""additionalProperties"": false,
+        ""properties"": {
+          ""Bar"": {
+            ""type"": [
+              ""null"",
+              ""string""
+            ]
+          }
+        },
+        ""allOf"": [
+          {
+            ""$ref"": ""#/definitions/Animal""
+          }
+        ]
+      },
+      ""Animal"": {
+        ""type"": ""object"",
+        ""discriminator"": ""discriminator"",
+        ""x-abstract"": true,
+        ""additionalProperties"": false,
+        ""required"": [
+          ""discriminator""
+        ],
+        ""properties"": {
+          ""Foo"": {
+            ""type"": [
+              ""null"",
+              ""string""
+            ]
+          },
+          ""discriminator"": {
+            ""type"": ""string""
+          }
+        }
+      }
+    }
+  }
+");
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("[JsonInheritanceAttribute(\"Dog\", typeof(Dog))]"));
+        }
+    }
+}

--- a/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -1,7 +1,6 @@
 ﻿using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.ComponentModel;
-using System.Text;
 using System.Xml.Serialization;
 using Newtonsoft.Json;
 using NJsonSchema.CodeGeneration;
@@ -35,10 +34,12 @@ namespace Bonsai.Sgen
         public string Render()
         {
             var type = new CodeTypeDeclaration(Model.ClassName) { IsPartial = true };
+            var jsonSerializer = Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson);
+            var yamlSerializer = Settings.SerializerLibraries.HasFlag(SerializerLibraries.YamlDotNet);
             if (Model.IsAbstract) type.TypeAttributes |= System.Reflection.TypeAttributes.Abstract;
             if (Model.HasDiscriminator)
             {
-                if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson))
+                if (jsonSerializer)
                 {
                     type.CustomAttributes.Add(new CodeAttributeDeclaration(
                         new CodeTypeReference(typeof(JsonConverter)),
@@ -103,7 +104,7 @@ namespace Bonsai.Sgen
                         new CodeTypeReference(typeof(XmlIgnoreAttribute))));
                 }
 
-                if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson))
+                if (jsonSerializer)
                 {
                     var jsonProperty = new CodeAttributeDeclaration(
                         new CodeTypeReference(typeof(JsonPropertyAttribute)),
@@ -118,7 +119,7 @@ namespace Bonsai.Sgen
                     }
                     propertyDeclaration.CustomAttributes.Add(jsonProperty);
                 }
-                if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.YamlDotNet))
+                if (yamlSerializer)
                 {
                     propertyDeclaration.CustomAttributes.Add(new CodeAttributeDeclaration(
                         new CodeTypeReference(typeof(YamlMemberAttribute)),

--- a/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -66,6 +66,17 @@ namespace Bonsai.Sgen
             return new CodeArtifact(template.ClassName, CodeArtifactType.Class, CodeArtifactLanguage.CSharp, CodeArtifactCategory.Contract, template);
         }
 
+        private CodeArtifact ReplaceInitOnlyProperties(CodeArtifact modelType)
+        {
+            if (modelType.TypeName == nameof(NJsonSchema.Converters.JsonInheritanceAttribute))
+            {
+                var code = modelType.Code.Replace("{ get; }", "{ get; private set; }");
+                modelType = new CodeArtifact(modelType.TypeName, modelType.Type, modelType.Language, modelType.Category, code);
+            }
+
+            return modelType;
+        }
+
         public override IEnumerable<CodeArtifact> GenerateTypes()
         {
             var types = base.GenerateTypes();
@@ -87,7 +98,7 @@ namespace Bonsai.Sgen
                 extraTypes.Add(GenerateSerializer(deserializer));
             }
 
-            return types.Concat(extraTypes);
+            return types.Select(ReplaceInitOnlyProperties).Concat(extraTypes);
         }
     }
 }

--- a/Bonsai.Sgen/CSharpSerializerTemplate.cs
+++ b/Bonsai.Sgen/CSharpSerializerTemplate.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Xml.Serialization;
 using NJsonSchema;
 using NJsonSchema.CodeGeneration;
+using NJsonSchema.Converters;
 
 namespace Bonsai.Sgen
 {
@@ -15,7 +16,9 @@ namespace Bonsai.Sgen
             CodeGeneratorOptions options,
             CSharpCodeDomGeneratorSettings settings)
         {
-            ModelTypes = modelTypes;
+            ModelTypes = modelTypes.ExceptBy(
+                new[] { nameof(JsonInheritanceAttribute), nameof(JsonInheritanceConverter) },
+                r => r.TypeName);
             Provider = provider;
             Options = options;
             Settings = settings;


### PR DESCRIPTION
This PR extends class generation to support OpenAPI-style type discriminators.

This pattern is recognized by NJsonSchema, and its code generation framework already provides templates for implementing a `JsonInheritanceConverter` class and `JsonInheritanceAttribute` which can be used to annotate generated classes with arbitrary discriminator properties and type mappings.

A simple unit test for polymorphic deserialization of a discriminated type is provided.