### PR TITLE
Add support for YAML type discriminators

### DIFF
--- a/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
@@ -72,6 +72,7 @@ namespace Bonsai.Sgen.Tests
             var generator = TestHelper.CreateGenerator(schema);
             var code = generator.GenerateFile();
             Assert.IsTrue(code.Contains("[JsonInheritanceAttribute(\"Dog\", typeof(Dog))]"));
+            Assert.IsTrue(code.Contains("[YamlDiscriminator(\"discriminator\")]"));
             CompilerTestHelper.CompileFromSource(code);
         }
     }

--- a/Bonsai.Sgen/Bonsai.Sgen.csproj
+++ b/Bonsai.Sgen/Bonsai.Sgen.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="NJsonSchema.Yaml" Version="10.9.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CodeDom" Version="6.0.0" />
+    <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
 
 </Project>

--- a/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -31,12 +31,22 @@ namespace Bonsai.Sgen
             if (Model.IsAbstract) type.TypeAttributes |= System.Reflection.TypeAttributes.Abstract;
             if (Model.HasDiscriminator)
             {
-                if (jsonSerializer)
+                if (jsonSerializer || yamlSerializer)
                 {
-                    type.CustomAttributes.Add(new CodeAttributeDeclaration(
-                        new CodeTypeReference(typeof(JsonConverter)),
-                        new CodeAttributeArgument(new CodeTypeOfExpression(nameof(JsonInheritanceConverter))),
-                        new CodeAttributeArgument(new CodePrimitiveExpression(Model.Discriminator))));
+                    if (jsonSerializer)
+                    {
+                        type.CustomAttributes.Add(new CodeAttributeDeclaration(
+                            new CodeTypeReference(typeof(JsonConverter)),
+                            new CodeAttributeArgument(new CodeTypeOfExpression(nameof(JsonInheritanceConverter))),
+                            new CodeAttributeArgument(new CodePrimitiveExpression(Model.Discriminator))));
+                    }
+                    if (yamlSerializer)
+                    {
+                        type.CustomAttributes.Add(new CodeAttributeDeclaration(
+                            new CodeTypeReference("YamlDiscriminator"),
+                            new CodeAttributeArgument(new CodePrimitiveExpression(Model.Discriminator))));
+                    }
+
                     foreach (var derivedModel in Model.DerivedClasses)
                     {
                         type.CustomAttributes.Add(new CodeAttributeDeclaration(

--- a/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -96,8 +96,16 @@ namespace Bonsai.Sgen
             }
             if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.YamlDotNet))
             {
-                var serializer = new CSharpYamlSerializerTemplate(classTypes, _provider, _options, Settings);
-                var deserializer = new CSharpYamlDeserializerTemplate(schema, classTypes, _provider, _options, Settings);
+                var discriminatorTypes = classTypes.Where(modelType => modelType.Code.Contains("YamlDiscriminator")).ToList();
+                if (discriminatorTypes.Count > 0)
+                {
+                    var discriminator = new CSharpYamlDiscriminatorTemplate(_provider, _options, Settings);
+                    var typeInspector = new CSharpYamlDiscriminatorTypeInspectorTemplate(_provider, _options, Settings);
+                    extraTypes.Add(GenerateClass(discriminator));
+                    extraTypes.Add(GenerateClass(typeInspector));
+                }
+                var serializer = new CSharpYamlSerializerTemplate(classTypes, discriminatorTypes, _provider, _options, Settings);
+                var deserializer = new CSharpYamlDeserializerTemplate(schema, classTypes, discriminatorTypes, _provider, _options, Settings);
                 extraTypes.Add(GenerateClass(serializer));
                 extraTypes.Add(GenerateClass(deserializer));
             }

--- a/Bonsai.Sgen/CSharpYamlDiscriminatorTemplate.cs
+++ b/Bonsai.Sgen/CSharpYamlDiscriminatorTemplate.cs
@@ -1,0 +1,43 @@
+﻿using System.CodeDom;
+using System.CodeDom.Compiler;
+
+namespace Bonsai.Sgen
+{
+    internal class CSharpYamlDiscriminatorTemplate : CSharpCodeDomTemplate
+    {
+        public CSharpYamlDiscriminatorTemplate(
+            CodeDomProvider provider,
+            CodeGeneratorOptions options,
+            CSharpCodeDomGeneratorSettings settings)
+            : base(provider, options, settings)
+        {
+        }
+
+        public override string TypeName => "YamlDiscriminatorAttribute";
+
+        public override void BuildType(CodeTypeDeclaration type)
+        {
+            type.IsPartial = false;
+            type.Attributes |= MemberAttributes.Family;
+            type.BaseTypes.Add(typeof(Attribute));
+            type.CustomAttributes.Add(new CodeAttributeDeclaration(
+                new CodeTypeReference(typeof(AttributeUsageAttribute)),
+                new CodeAttributeArgument(new CodeBinaryOperatorExpression(
+                    new CodeFieldReferenceExpression(
+                        new CodeTypeReferenceExpression(typeof(AttributeTargets)),
+                        nameof(AttributeTargets.Class)),
+                    CodeBinaryOperatorType.BitwiseOr,
+                    new CodeFieldReferenceExpression(
+                        new CodeTypeReferenceExpression(typeof(AttributeTargets)),
+                        nameof(AttributeTargets.Interface))))));
+            type.Members.Add(new CodeSnippetTypeMember(
+@"    public YamlDiscriminatorAttribute(string discriminator)
+    {
+        Discriminator = discriminator;
+    }
+
+    public string Discriminator { get; private set; }
+"));
+        }
+    }
+}

--- a/Bonsai.Sgen/CSharpYamlDiscriminatorTypeInspectorTemplate.cs
+++ b/Bonsai.Sgen/CSharpYamlDiscriminatorTypeInspectorTemplate.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YamlDotNet.Serialization.TypeInspectors;
+
+namespace Bonsai.Sgen
+{
+    internal class CSharpYamlDiscriminatorTypeInspectorTemplate : CSharpCodeDomTemplate
+    {
+        public CSharpYamlDiscriminatorTypeInspectorTemplate(
+            CodeDomProvider provider,
+            CodeGeneratorOptions options,
+            CSharpCodeDomGeneratorSettings settings)
+            : base(provider, options, settings)
+        {
+        }
+
+        public override string TypeName => "YamlDiscriminatorTypeInspector";
+
+        public override void BuildType(CodeTypeDeclaration type)
+        {
+            type.IsPartial = false;
+            type.BaseTypes.Add(typeof(TypeInspectorSkeleton));
+            type.Members.Add(new CodeSnippetTypeMember(
+@$"    readonly YamlDotNet.Serialization.ITypeInspector innerTypeDescriptor;
+
+    public {TypeName}(YamlDotNet.Serialization.ITypeInspector innerTypeDescriptor)
+    {{
+        if (innerTypeDescriptor == null)
+        {{
+            throw new System.ArgumentNullException(""innerTypeDescriptor"");
+        }}
+
+        this.innerTypeDescriptor = innerTypeDescriptor;
+    }}
+
+    public override System.Collections.Generic.IEnumerable<YamlDotNet.Serialization.IPropertyDescriptor> GetProperties(System.Type type, object container)
+    {{
+        var innerProperties = innerTypeDescriptor.GetProperties(type, container);
+
+        var discriminatorAttribute = (YamlDiscriminatorAttribute)System.Attribute.GetCustomAttribute(type, typeof(YamlDiscriminatorAttribute));
+        var inheritanceAttributes = (JsonInheritanceAttribute[])System.Attribute.GetCustomAttributes(type, typeof(JsonInheritanceAttribute));
+        var typeMatch = System.Array.Find(inheritanceAttributes, attribute => attribute.Type == type);
+        if (discriminatorAttribute != null && typeMatch != null)
+        {{
+            return System.Linq.Enumerable.Concat(new[]
+            {{
+                new DiscriminatorPropertyDescriptor(discriminatorAttribute.Discriminator, typeMatch.Key)
+            }}, innerProperties);
+        }}
+
+        return innerProperties;
+    }}
+
+    class DiscriminatorPropertyDescriptor : YamlDotNet.Serialization.IPropertyDescriptor
+    {{
+        readonly string key;
+
+        public DiscriminatorPropertyDescriptor(string discriminator, string value)
+        {{
+            ScalarStyle = YamlDotNet.Core.ScalarStyle.Plain;
+            Name = discriminator;
+            key = value;
+        }}
+
+        public string Name {{ get; private set; }}
+
+        public bool CanWrite
+        {{
+            get {{ return true; }}
+        }}
+
+        public System.Type Type
+        {{
+            get {{ return typeof(string); }}
+        }}
+
+        public System.Type TypeOverride {{ get; set; }}
+
+        public int Order {{ get; set; }}
+
+        public YamlDotNet.Core.ScalarStyle ScalarStyle {{ get; set; }}
+
+        public T GetCustomAttribute<T>() where T : System.Attribute
+        {{
+            return null;
+        }}
+
+        public YamlDotNet.Serialization.IObjectDescriptor Read(object target)
+        {{
+            return new YamlDotNet.Serialization.ObjectDescriptor(key, Type, Type, ScalarStyle);
+        }}
+
+        public void Write(object target, object value)
+        {{
+        }}
+    }}"));
+        }
+    }
+}


### PR DESCRIPTION
This PR extends class generation to support OpenAPI-style type discriminators for the YAML serializer.

YamlDotNet has recently provided built-in support for type discriminators. Unfortunately the built-in classes do not support the specified discriminator property to be "hidden" in the model types in the same way that NJsonSchema code generation implements for JSON.Net.

Fortunately, it was possible to remedy this by using the type inspector classes to provide the missing discriminator properties.

Fixes #7 