### PR TITLE
Generate ToString override with member formatting

### DIFF
--- a/Bonsai.Sgen.Tests/ToStringGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/ToStringGenerationTests.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema;
+using System.Threading.Tasks;
+
+namespace Bonsai.Sgen.Tests
+{
+    [TestClass]
+    public class ToStringGenerationTests
+    {
+        private static Task<JsonSchema> CreateTestSchema()
+        {
+            return JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""type"": ""object"",
+    ""title"": ""Container"",
+    ""properties"": {
+      ""BaseType"": {
+        ""oneOf"": [
+          {
+            ""$ref"": ""#/definitions/BaseType""
+          },
+          {
+            ""type"": ""null""
+          }
+        ]
+      }
+    },
+    ""definitions"": {
+      ""DerivedType"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""Bar"": {
+            ""type"": [
+              ""null"",
+              ""string""
+            ]
+          },
+          ""Baz"": {
+            ""type"": [
+              ""null"",
+              ""integer""
+            ]
+          }
+        },
+        ""allOf"": [
+          {
+            ""$ref"": ""#/definitions/BaseType""
+          }
+        ]
+      },
+      ""BaseType"": {
+        ""type"": ""object""
+      }
+    }
+  }
+");
+        }
+
+        [TestMethod]
+        public async Task GenerateToStringOverride_FormatMultipleProperties()
+        {
+            var schema = await CreateTestSchema();
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            CompilerTestHelper.CompileFromSource(code);
+        }
+    }
+}

--- a/Bonsai.Sgen.Tests/ToStringGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/ToStringGenerationTests.cs
@@ -49,6 +49,14 @@ namespace Bonsai.Sgen.Tests
           }
         ]
       },
+      ""EmptyDerivedType"": {
+        ""type"": ""object"",
+        ""allOf"": [
+          {
+            ""$ref"": ""#/definitions/BaseType""
+          }
+        ]
+      },
       ""BaseType"": {
         ""type"": ""object""
       }

--- a/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -233,25 +233,33 @@ namespace Bonsai.Sgen
                 Parameters = { stringBuilderParameter },
                 ReturnType = new CodeTypeReference(typeof(bool))
             };
-            if (Model.BaseClass != null)
+            if (Model.BaseClass != null && propertyCount == 0)
             {
-                printMembersMethod.Statements.Add(new CodeConditionStatement(
-                    new CodeMethodInvokeExpression(new CodeBaseReferenceExpression(), PrintMembersMethodName, stringBuilderVariable),
-                    new CodeExpressionStatement(
-                        new CodeMethodInvokeExpression(stringBuilderVariable, AppendMethodName, new CodePrimitiveExpression(", ")))));
+                printMembersMethod.Statements.Add(new CodeMethodReturnStatement(
+                    new CodeMethodInvokeExpression(new CodeBaseReferenceExpression(), PrintMembersMethodName, stringBuilderVariable)));
             }
+            else
+            {
+                if (Model.BaseClass != null)
+                {
+                    printMembersMethod.Statements.Add(new CodeConditionStatement(
+                        new CodeMethodInvokeExpression(new CodeBaseReferenceExpression(), PrintMembersMethodName, stringBuilderVariable),
+                        new CodeExpressionStatement(
+                            new CodeMethodInvokeExpression(stringBuilderVariable, AppendMethodName, new CodePrimitiveExpression(", ")))));
+                }
 
-            var propertyIndex = 0;
-            foreach (var property in Model.Properties)
-            {
-                printMembersMethod.Statements.Add(new CodeMethodInvokeExpression(
-                    stringBuilderVariable,
-                    AppendMethodName,
-                    new CodeSnippetExpression(
-                        $"\"{property.Name} = \" + {property.FieldName}" +
-                        (++propertyIndex < propertyCount ? " + \", \"" : string.Empty))));
+                var propertyIndex = 0;
+                foreach (var property in Model.Properties)
+                {
+                    printMembersMethod.Statements.Add(new CodeMethodInvokeExpression(
+                        stringBuilderVariable,
+                        AppendMethodName,
+                        new CodeSnippetExpression(
+                            $"\"{property.Name} = \" + {property.FieldName}" +
+                            (++propertyIndex < propertyCount ? " + \", \"" : string.Empty))));
+                }
+                printMembersMethod.Statements.Add(new CodeMethodReturnStatement(new CodePrimitiveExpression(propertyCount > 0)));
             }
-            printMembersMethod.Statements.Add(new CodeMethodReturnStatement(new CodePrimitiveExpression(propertyCount > 0)));
 
             type.Members.Add(printMembersMethod);
             if (Model.BaseClass == null)


### PR DESCRIPTION
Inspired by C# [record type formatting for display](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record#built-in-formatting-for-display), this PR introduces automatic generation of a `ToString` and a virtual `PrintMembers` method.

Various edge cases were captured for different combinations of derived types and empty types and a compiler unit test was added as a simple regression test to ensure the validity of generated code.

Fixes #10 