### PR TITLE
Use StringEnumConverter for string enum types

### DIFF
--- a/Bonsai.Sgen.Tests/EnumGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/EnumGenerationTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NJsonSchema;
@@ -43,6 +44,38 @@ namespace Bonsai.Sgen.Tests
             var code = generator.GenerateFile();
             Assert.IsTrue(code.Contains("EnumMemberAttribute(Value=\"A\")"));
             Assert.IsTrue(code.Contains("YamlMemberAttribute(Alias=\"A\")"));
+        }
+
+        [TestMethod]
+        public async Task GenerateStringEnum_StringEnumTypeDefinitionWithStringEnumConverter()
+        {
+            var schema = await JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""type"": ""object"",
+    ""title"": ""Container"",
+    ""additionalProperties"": false,
+    ""properties"": {
+      ""Enum"": {
+         ""$ref"": ""#/definitions/StringEnum""
+      }
+    },
+    ""definitions"": {
+      ""StringEnum"": {
+         ""enum"": [
+            ""This is a string A"",
+            ""This is a string B""
+         ],
+         ""title"": ""StringEnum"",
+         ""type"": ""string""
+      }
+    }
+  }
+");
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("StringEnumConverter"));
+            CompilerTestHelper.CompileFromSource(code);
         }
     }
 }

--- a/Bonsai.Sgen/CSharpEnumTemplate.cs
+++ b/Bonsai.Sgen/CSharpEnumTemplate.cs
@@ -3,6 +3,8 @@ using System.CodeDom.Compiler;
 using NJsonSchema.CodeGeneration.CSharp.Models;
 using YamlDotNet.Serialization;
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Bonsai.Sgen
 {
@@ -31,6 +33,13 @@ namespace Bonsai.Sgen
                 type.Comments.Add(new CodeCommentStatement("<summary>", docComment: true));
                 type.Comments.Add(new CodeCommentStatement(Model.Description, docComment: true));
                 type.Comments.Add(new CodeCommentStatement("</summary>", docComment: true));
+            }
+
+            if (Model.IsStringEnum && Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson))
+            {
+                type.CustomAttributes.Add(new CodeAttributeDeclaration(
+                    new CodeTypeReference(typeof(JsonConverter)),
+                    new CodeAttributeArgument(new CodeTypeOfExpression(typeof(StringEnumConverter)))));
             }
 
             if (Model.IsEnumAsBitFlags)


### PR DESCRIPTION
This PR ensures that `StringEnumConverter` is used for all string types constrained by `enum` in the JSON schema. This makes serialization consistent between YAML and JSON and ensures all allowed values are written as their original strings back to JSON.

Fixes #11 