### PR TITLE
Generate serializer library provenance

### DIFF
--- a/Bonsai.Sgen/Bonsai.Sgen.csproj
+++ b/Bonsai.Sgen/Bonsai.Sgen.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NJsonSchema.CodeGeneration" Version="10.9.0" />
     <PackageReference Include="NJsonSchema.CodeGeneration.CSharp" Version="10.9.0" />
     <PackageReference Include="NJsonSchema.Yaml" Version="10.9.0" />

--- a/Bonsai.Sgen/CSharpCodeDomTemplate.cs
+++ b/Bonsai.Sgen/CSharpCodeDomTemplate.cs
@@ -8,6 +8,8 @@ namespace Bonsai.Sgen
     internal abstract class CSharpCodeDomTemplate : ITemplate
     {
         private static readonly AssemblyName GeneratorAssemblyName = Assembly.GetExecutingAssembly().GetName();
+        private static readonly AssemblyName NewtonsoftJsonAssemblyName = typeof(Newtonsoft.Json.JsonConvert).Assembly.GetName();
+        private static readonly AssemblyName YamlDotNetAssemblyName = typeof(YamlDotNet.Core.Parser).Assembly.GetName();
 
         public CSharpCodeDomTemplate(
             CodeDomProvider provider,
@@ -29,13 +31,32 @@ namespace Bonsai.Sgen
 
         public abstract void BuildType(CodeTypeDeclaration type);
 
+        private static string GetVersionString(AssemblyName assemblyName)
+        {
+            return $"{assemblyName.Name} v{assemblyName.Version}";
+        }
+
+        private string GetVersionString()
+        {
+            var serializerLibraries = new List<string>();
+            if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson))
+            {
+                serializerLibraries.Add(GetVersionString(NewtonsoftJsonAssemblyName));
+            }
+            if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.YamlDotNet))
+            {
+                serializerLibraries.Add(GetVersionString(YamlDotNetAssemblyName));
+            }
+            return $"{GeneratorAssemblyName.Version} ({string.Join(", ", serializerLibraries)})";
+        }
+
         public string Render()
         {
             var type = new CodeTypeDeclaration(TypeName) { IsPartial = true };
             type.CustomAttributes.Add(new CodeAttributeDeclaration(
                 new CodeTypeReference(typeof(GeneratedCodeAttribute)),
                 new CodeAttributeArgument(new CodePrimitiveExpression(GeneratorAssemblyName.Name)),
-                new CodeAttributeArgument(new CodePrimitiveExpression(GeneratorAssemblyName.Version?.ToString()))));
+                new CodeAttributeArgument(new CodePrimitiveExpression(GetVersionString()))));
             BuildType(type);
 
             using var writer = new StringWriter();

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# sgen
-Tool for automatically generating YML serialization classes from schema files
+# Serializer Generator Tool
+
+Tool for automatically generating YAML / JSON serialization classes and constructor operators from schema files.
 
 ## Getting Started
 
-1. Navigate to the [Bonsai.Sgen toolbox NuGet package](https://www.nuget.org/packages/Bonsai.Sgen/)
-2. Click `NET CLI (Local)` and copy the two suggested commands. E.g.:
+1. Navigate to the [Bonsai.Sgen NuGet tool package](https://www.nuget.org/packages/Bonsai.Sgen/)
+2. Click `.NET CLI (Local)` and copy the two suggested commands. E.g.:
 
     ```cmd
     dotnet new tool-manifest # if you are setting up this repo
-    dotnet tool install --local Bonsai.Sgen --version 0.1.0
+    dotnet tool install --local Bonsai.Sgen --version 0.2.0
     ```
 
 3. To view the tool help reference documentation, run:
@@ -17,25 +18,31 @@ Tool for automatically generating YML serialization classes from schema files
     dotnet bonsai.sgen --help
     ```
 
-4. To generate serialization classes from a schema file:
+4. To generate YAML serialization classes from a schema file:
 
     ```cmd
-    dotnet bonsai.sgen --schema schema.json
+    dotnet bonsai.sgen --schema schema.json --serializer YamlDotNet
     ```
 
-5. Copy the generated class file to your project `Extensions` folder.
+5. To generate JSON serialization classes from a schema file:
 
-6. Add the necessary package references to your `Extensions.csproj` file. For instance:
+    ```cmd
+    dotnet bonsai.sgen --schema schema.json --serializer NewtonsoftJson
+    ```
+
+6. Copy the generated class file to your project `Extensions` folder.
+
+7. Add the necessary package references to your `Extensions.csproj` file. For example:
 
     ```xml
     <ItemGroup>
         <PackageReference Include="Bonsai.Core" Version="2.8.0" />
-        <PackageReference Include="YamlDotNet" Version="12.0.2" />
+        <PackageReference Include="YamlDotNet" Version="13.7.1" />
     </ItemGroup>
     </Project>
     ```
 
-7. To restore the tool at any point, run:
+8. To restore the tool at any point, run:
 
     ```cmd
     dotnet tool restore


### PR DESCRIPTION
This PR ensures that auto-generated version strings include all configured serializer libraries and their corresponding versions used by the generator. This is useful for provenance tracking and to help extension authors include the correct serializer dependencies in their project files.