### PR TITLE
Generate type matching operator for derived types

### DIFF
--- a/Bonsai.Sgen/CSharpClassCodeArtifact.cs
+++ b/Bonsai.Sgen/CSharpClassCodeArtifact.cs
@@ -1,0 +1,20 @@
+﻿using NJsonSchema.CodeGeneration;
+
+namespace Bonsai.Sgen
+{
+    internal class CSharpClassCodeArtifact : CodeArtifact
+    {
+        public CSharpClassCodeArtifact(CSharpClassTemplateModel model, ITemplate template) : base(
+            model.ClassName,
+            model.BaseClassName,
+            CodeArtifactType.Class,
+            CodeArtifactLanguage.CSharp,
+            CodeArtifactCategory.Contract,
+            template)
+        {
+            Model = model;
+        }
+
+        public CSharpClassTemplateModel Model { get; }
+    }
+}

--- a/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -87,6 +87,11 @@ namespace Bonsai.Sgen
                 .Where(type => type.Type == CodeArtifactType.Class)
                 .ExceptBy(new[] { nameof(JsonInheritanceAttribute), nameof(JsonInheritanceConverter) }, r => r.TypeName)
                 .ToList();
+            foreach (var type in classTypes.Where(type => type.BaseTypeName != null))
+            {
+                var matchTemplate = new CSharpTypeMatchTemplate(type, _provider, _options, Settings);
+                extraTypes.Add(GenerateClass(matchTemplate));
+            }
             if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson))
             {
                 var serializer = new CSharpJsonSerializerTemplate(classTypes, _provider, _options, Settings);

--- a/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -87,7 +87,8 @@ namespace Bonsai.Sgen
                               let classType = type as CSharpClassCodeArtifact
                               where classType != null
                               select classType).ToList();
-            foreach (var type in classTypes.Where(type => type.BaseTypeName != null))
+            var discriminatorTypes = classTypes.Where(modelType => modelType.Model.HasDiscriminator).ToList();
+            foreach (var type in discriminatorTypes)
             {
                 var matchTemplate = new CSharpTypeMatchTemplate(type, _provider, _options, Settings);
                 extraTypes.Add(GenerateClass(matchTemplate));
@@ -101,7 +102,6 @@ namespace Bonsai.Sgen
             }
             if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.YamlDotNet))
             {
-                var discriminatorTypes = classTypes.Where(modelType => modelType.Model.HasDiscriminator).ToList();
                 if (discriminatorTypes.Count > 0)
                 {
                     var discriminator = new CSharpYamlDiscriminatorTemplate(_provider, _options, Settings);

--- a/Bonsai.Sgen/CSharpTypeMatchTemplate.cs
+++ b/Bonsai.Sgen/CSharpTypeMatchTemplate.cs
@@ -1,0 +1,66 @@
+﻿using System.CodeDom;
+using System.CodeDom.Compiler;
+using NJsonSchema.CodeGeneration;
+
+namespace Bonsai.Sgen
+{
+    internal class CSharpTypeMatchTemplate : CSharpCodeDomTemplate
+    {
+        public CSharpTypeMatchTemplate(
+            CodeArtifact modelType,
+            CodeDomProvider provider,
+            CodeGeneratorOptions options,
+            CSharpCodeDomGeneratorSettings settings)
+            : base(provider, options, settings)
+        {
+            ModelType = modelType;
+        }
+
+        public CodeArtifact ModelType { get; }
+
+        public override string TypeName => $"{ModelType.TypeName}Match";
+
+        public override void BuildType(CodeTypeDeclaration type)
+        {
+            var sourceParameter = new CodeParameterDeclarationExpression(
+                new CodeTypeReference(typeof(IObservable<>))
+                {
+                    TypeArguments = { new CodeTypeReference(ModelType.BaseTypeName) }
+                }, "source");
+            var processMethod = new CodeMemberMethod
+            {
+                Name = "Process",
+                Attributes = MemberAttributes.Public | MemberAttributes.Final,
+                Parameters = { sourceParameter },
+                ReturnType = new CodeTypeReference(typeof(IObservable<>))
+                {
+                    TypeArguments = { new CodeTypeReference(ModelType.TypeName) }
+                },
+                Statements =
+                {
+                    new CodeExpressionStatement(new CodeSnippetExpression(
+@$"return System.Reactive.Linq.Observable.Create<{ModelType.TypeName}>(observer =>
+        {{
+            var sourceObserver = System.Reactive.Observer.Create<{ModelType.BaseTypeName}>(
+                value =>
+                {{
+                    var match = value as {ModelType.TypeName};
+                    if (match != null) observer.OnNext(match);
+                }},
+                observer.OnError,
+                observer.OnCompleted);
+            return System.ObservableExtensions.SubscribeSafe(source, sourceObserver);
+        }});"))
+                }
+            };
+            type.Members.Add(processMethod);
+            type.CustomAttributes.Add(new CodeAttributeDeclaration(
+                new CodeTypeReference("Bonsai.CombinatorAttribute")));
+            type.CustomAttributes.Add(new CodeAttributeDeclaration(
+                new CodeTypeReference("Bonsai.WorkflowElementCategoryAttribute"),
+                new CodeAttributeArgument(new CodeFieldReferenceExpression(
+                    new CodeTypeReferenceExpression("Bonsai.ElementCategory"),
+                    "Combinator"))));
+        }
+    }
+}

--- a/Bonsai.Sgen/CSharpTypeMatchTemplate.cs
+++ b/Bonsai.Sgen/CSharpTypeMatchTemplate.cs
@@ -1,13 +1,14 @@
 ﻿using System.CodeDom;
 using System.CodeDom.Compiler;
-using NJsonSchema.CodeGeneration;
+using System.ComponentModel;
+using System.Xml.Serialization;
 
 namespace Bonsai.Sgen
 {
     internal class CSharpTypeMatchTemplate : CSharpCodeDomTemplate
     {
         public CSharpTypeMatchTemplate(
-            CodeArtifact modelType,
+            CSharpClassCodeArtifact modelType,
             CodeDomProvider provider,
             CodeGeneratorOptions options,
             CSharpCodeDomGeneratorSettings settings)
@@ -16,51 +17,76 @@ namespace Bonsai.Sgen
             ModelType = modelType;
         }
 
-        public CodeArtifact ModelType { get; }
+        public CSharpClassCodeArtifact ModelType { get; }
 
-        public override string TypeName => $"{ModelType.TypeName}Match";
+        public override string TypeName => $"Match{ModelType.TypeName}";
 
         public override void BuildType(CodeTypeDeclaration type)
         {
-            var sourceParameter = new CodeParameterDeclarationExpression(
-                new CodeTypeReference(typeof(IObservable<>))
-                {
-                    TypeArguments = { new CodeTypeReference(ModelType.BaseTypeName) }
-                }, "source");
-            var processMethod = new CodeMemberMethod
-            {
-                Name = "Process",
-                Attributes = MemberAttributes.Public | MemberAttributes.Final,
-                Parameters = { sourceParameter },
-                ReturnType = new CodeTypeReference(typeof(IObservable<>))
-                {
-                    TypeArguments = { new CodeTypeReference(ModelType.TypeName) }
-                },
-                Statements =
-                {
-                    new CodeExpressionStatement(new CodeSnippetExpression(
-@$"return System.Reactive.Linq.Observable.Create<{ModelType.TypeName}>(observer =>
-        {{
-            var sourceObserver = System.Reactive.Observer.Create<{ModelType.BaseTypeName}>(
-                value =>
-                {{
-                    var match = value as {ModelType.TypeName};
-                    if (match != null) observer.OnNext(match);
-                }},
-                observer.OnError,
-                observer.OnCompleted);
-            return System.ObservableExtensions.SubscribeSafe(source, sourceObserver);
-        }});"))
-                }
-            };
-            type.Members.Add(processMethod);
+            type.BaseTypes.Add(new CodeTypeReference("Bonsai.Expressions.SingleArgumentExpressionBuilder"));
             type.CustomAttributes.Add(new CodeAttributeDeclaration(
-                new CodeTypeReference("Bonsai.CombinatorAttribute")));
+                new CodeTypeReference(typeof(DefaultPropertyAttribute)),
+                new CodeAttributeArgument(new CodePrimitiveExpression("Type"))));
             type.CustomAttributes.Add(new CodeAttributeDeclaration(
                 new CodeTypeReference("Bonsai.WorkflowElementCategoryAttribute"),
                 new CodeAttributeArgument(new CodeFieldReferenceExpression(
                     new CodeTypeReferenceExpression("Bonsai.ElementCategory"),
                     "Combinator"))));
+            foreach (var modelType in ModelType.Model.DerivedClasses)
+            {
+                type.CustomAttributes.Add(new CodeAttributeDeclaration(
+                    new CodeTypeReference(typeof(XmlIncludeAttribute)),
+                    new CodeAttributeArgument(new CodeTypeOfExpression(
+                        new CodeTypeReference(
+                            "Bonsai.Expressions.TypeMapping",
+                            new CodeTypeReference(modelType.ClassName))))));
+            }
+
+            type.Members.Add(new CodeSnippetTypeMember(
+@$"    public Bonsai.Expressions.TypeMapping Type {{ get; set; }}
+
+    public override System.Linq.Expressions.Expression Build(System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression> arguments)
+    {{
+        var typeMapping = Type;
+        var returnType = typeMapping != null ? typeMapping.GetType().GetGenericArguments()[0] : typeof({ModelType.TypeName});
+        return System.Linq.Expressions.Expression.Call(
+            typeof({TypeName}),
+            ""Process"",
+            new System.Type[] {{ returnType }},
+            System.Linq.Enumerable.Single(arguments));
+    }}
+"));
+            var sourceTypeReference = new CodeTypeReference(ModelType.TypeName);
+            var genericTypeParameter = new CodeTypeParameter("TResult") { Constraints = { sourceTypeReference } };
+            var sourceParameter = new CodeParameterDeclarationExpression(
+                new CodeTypeReference(typeof(IObservable<>)) { TypeArguments = { sourceTypeReference } }, "source");
+            type.Members.Add(new CodeMemberMethod
+            {
+                Name = "Process",
+                Attributes = MemberAttributes.Private | MemberAttributes.Static,
+                TypeParameters = { genericTypeParameter },
+                Parameters = { sourceParameter },
+                ReturnType = new CodeTypeReference(typeof(IObservable<>))
+                {
+                    TypeArguments = { new CodeTypeReference(genericTypeParameter) }
+                },
+                Statements =
+                {
+                    new CodeExpressionStatement(new CodeSnippetExpression(
+@$"return System.Reactive.Linq.Observable.Create<{genericTypeParameter.Name}>(observer =>
+        {{
+            var sourceObserver = System.Reactive.Observer.Create<{ModelType.TypeName}>(
+                value =>
+                {{
+                    var match = value as {genericTypeParameter.Name};
+                    if (match != null) observer.OnNext(match);
+                }},
+                observer.OnError,
+                observer.OnCompleted);
+            return System.ObservableExtensions.SubscribeSafe(source, sourceObserver);
+        }})"))
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
This PR automatically generates type matching operators for discriminated union types. This will allow easier handling of polymorphic types by simultaneously filtering and casting sequences of base types.

The current implementation generates a single type matching operator for each base type declaring a discriminator property. A type mapping property is provided to select the concrete target type. Available property values are taken from the list of derived types extracted from the input schema.