### PR TITLE
Ensure inheritance attribute is generated

### DIFF
--- a/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -82,6 +82,24 @@ namespace Bonsai.Sgen
         {
             var types = base.GenerateTypes();
             var extraTypes = new List<CodeArtifact>();
+
+            if (!Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson) &&
+                types.Any(r => r.Code.Contains(nameof(JsonInheritanceAttribute))))
+            {
+                if (Settings.ExcludedTypeNames?.Contains(nameof(JsonInheritanceAttribute)) != true)
+                {
+                    var model = new JsonInheritanceConverterTemplateModel(Settings);
+                    var template = Settings.TemplateFactory.CreateTemplate("CSharp", nameof(JsonInheritanceAttribute), model);
+                    var artifact = new CodeArtifact(
+                        nameof(JsonInheritanceAttribute),
+                        CodeArtifactType.Class,
+                        CodeArtifactLanguage.CSharp,
+                        CodeArtifactCategory.Utility,
+                        template);
+                    extraTypes.Add(ReplaceInitOnlyProperties(artifact));
+                }
+            }
+
             var schema = (JsonSchema)RootObject;
             var classTypes = (from type in types
                               let classType = type as CSharpClassCodeArtifact

--- a/Bonsai.Sgen/JsonSchemaExtensions.cs
+++ b/Bonsai.Sgen/JsonSchemaExtensions.cs
@@ -4,7 +4,7 @@ using NJsonSchema.Visitors;
 
 namespace Bonsai.Sgen
 {
-    public static class JsonSchemaExtensions
+    internal static class JsonSchemaExtensions
     {
         public static JsonSchema WithUniqueDiscriminatorProperties(this JsonSchema schema)
         {

--- a/Bonsai.Sgen/SerializerLibraries.cs
+++ b/Bonsai.Sgen/SerializerLibraries.cs
@@ -1,7 +1,7 @@
 ﻿namespace Bonsai.Sgen
 {
     [Flags]
-    internal enum SerializerLibraries
+    public enum SerializerLibraries
     {
         None = 0x0,
         NewtonsoftJson = 0x1,


### PR DESCRIPTION
This PR fixes one edge case with discriminator code generation where the reused `JsonInheritanceAttribute` was not being automatically generated due to missing declaration of `JsonConverterAttribute`, when YAML-only libraries were selected.

Parametric regression testing was added to ensure all serializer library combinations are included in the tests.