### PR TITLE
Support inline oneOf discriminated properties

### DIFF
--- a/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
@@ -7,6 +7,22 @@ namespace Bonsai.Sgen.Tests
     [TestClass]
     public class DiscriminatorGenerationTests
     {
+        static void AssertDiscriminatorAttribute(string code, SerializerLibraries serializerLibraries, string discriminatorName)
+        {
+            if (serializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson))
+            {
+                Assert.IsTrue(
+                    code.Contains($"[Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), \"{discriminatorName}\")]"),
+                    message: "Missing JSON discriminator attribute.");
+            }
+            if (serializerLibraries.HasFlag(SerializerLibraries.YamlDotNet))
+            {
+                Assert.IsTrue(
+                    code.Contains($"[YamlDiscriminator(\"{discriminatorName}\")]"),
+                    message: "Missing YAML discriminator attribute.");
+            }
+        }
+
         [TestMethod]
         [DataRow(SerializerLibraries.YamlDotNet)]
         [DataRow(SerializerLibraries.NewtonsoftJson)]
@@ -80,18 +96,7 @@ namespace Bonsai.Sgen.Tests
             var generator = TestHelper.CreateGenerator(schema, serializerLibraries);
             var code = generator.GenerateFile();
             Assert.IsTrue(code.Contains("[JsonInheritanceAttribute(\"DogType\", typeof(Dog))]"));
-            if (serializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson))
-            {
-                Assert.IsTrue(
-                    code.Contains("[Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), \"discriminator\")]"),
-                    message: "Missing JSON discriminator attribute.");
-            }
-            if (serializerLibraries.HasFlag(SerializerLibraries.YamlDotNet))
-            {
-                Assert.IsTrue(
-                    code.Contains("[YamlDiscriminator(\"discriminator\")]"),
-                    message: "Missing YAML discriminator attribute.");
-            }
+            AssertDiscriminatorAttribute(code, serializerLibraries, "discriminator");
             CompilerTestHelper.CompileFromSource(code);
         }
 
@@ -194,18 +199,7 @@ namespace Bonsai.Sgen.Tests
             Assert.IsTrue(!code.Contains("public enum DogKind"), "Discriminator property is repeated in derived types.");
             Assert.IsTrue(code.Contains("List<Animal> Animals"), "Container array element type does not match base type.");
             Assert.IsTrue(code.Contains("[JsonInheritanceAttribute(\"Dog\", typeof(Dog))]"));
-            if (serializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson))
-            {
-                Assert.IsTrue(
-                    code.Contains("[Newtonsoft.Json.JsonConverter(typeof(JsonInheritanceConverter), \"kind\")]"),
-                    message: "Missing JSON discriminator attribute.");
-            }
-            if (serializerLibraries.HasFlag(SerializerLibraries.YamlDotNet))
-            {
-                Assert.IsTrue(
-                    code.Contains("[YamlDiscriminator(\"kind\")]"),
-                    message: "Missing YAML discriminator attribute.");
-            }
+            AssertDiscriminatorAttribute(code, serializerLibraries, "kind");
             CompilerTestHelper.CompileFromSource(code);
         }
     }

--- a/Bonsai.Sgen/JsonSchemaExtensions.cs
+++ b/Bonsai.Sgen/JsonSchemaExtensions.cs
@@ -15,17 +15,41 @@ namespace Bonsai.Sgen
 
         class DiscriminatorSchemaVisitor : JsonSchemaVisitorBase
         {
-            public DiscriminatorSchemaVisitor(object rootObject)
+            public DiscriminatorSchemaVisitor(JsonSchema rootObject)
             {
                 RootObject = rootObject;
             }
 
-            public object RootObject { get; }
+            public JsonSchema RootObject { get; }
 
             protected override JsonSchema VisitSchema(JsonSchema schema, string path, string typeNameHint)
             {
                 if (schema.DiscriminatorObject != null)
                 {
+                    if (schema is JsonSchemaProperty schemaProperty)
+                    {
+                        if (!RootObject.Definitions.ContainsKey(typeNameHint))
+                        {
+                            var discriminatorSchema = new JsonSchema();
+                            discriminatorSchema.DiscriminatorObject = schemaProperty.DiscriminatorObject;
+                            discriminatorSchema.IsAbstract = schemaProperty.IsAbstract;
+                            foreach (var derivedSchema in schemaProperty.OneOf)
+                            {
+                                if (derivedSchema.IsNullable(SchemaType.JsonSchema))
+                                {
+                                    continue;
+                                }
+
+                                derivedSchema.ActualSchema.AllOf.Add(new JsonSchema { Reference = discriminatorSchema });
+                            }
+                            RootObject.Definitions.Add(typeNameHint, discriminatorSchema);
+                        }
+
+                        schemaProperty.DiscriminatorObject = null;
+                        schemaProperty.IsAbstract = false;
+                        return schema;
+                    }
+
                     foreach (var derivedSchema in schema.GetDerivedSchemas(RootObject).Keys)
                     {
                         foreach (var property in derivedSchema.Properties.Keys.ToList())


### PR DESCRIPTION
Pydantic exported schemas do not commonly support `allOf` inheritance (see https://github.com/pydantic/pydantic/issues/478) and regularly emit inline property schemas comprised of a `discriminator` with custom mappings and a `oneOf` constraint.

Following support for `oneOf` introduced in #23 this PR extends this support to inline discriminated schema properties by converting the original schema into an inheritance tree using `allOf`.

The main current limitation is for definitions participating in multiple distinct discriminated unions: in this case the first discriminator will be used as the root of the inheritance and no multiple inheritance is allowed.

Fixes #25 