### PR TITLE
Add name generators for property type and enum

### DIFF
--- a/Bonsai.Sgen.Tests/CasingGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/CasingGenerationTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema;
+
+namespace Bonsai.Sgen.Tests
+{
+    [TestClass]
+    public class CasingGenerationTests
+    {
+        private static Task<JsonSchema> CreateTestSchema()
+        {
+            return JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""type"": ""object"",
+    ""title"": ""Container"",
+    ""properties"": {
+      ""base_type"": {
+        ""oneOf"": [
+          {
+            ""$ref"": ""#/definitions/thing_container""
+          },
+          {
+            ""type"": ""null""
+          }
+        ]
+      }
+    },
+    ""definitions"": {
+      ""thing_container"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""bar"": {
+            ""type"": [
+              ""null"",
+              ""string""
+            ]
+          }
+        }
+      }
+    }
+}
+");
+        }
+
+        [TestMethod]
+        public async Task GenerateFromSnakeCase_GeneratePascalCaseNames()
+        {
+            var schema = await CreateTestSchema();
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("public ThingContainer BaseType"), "Incorrect casing for property name.");
+            CompilerTestHelper.CompileFromSource(code);
+        }
+    }
+}

--- a/Bonsai.Sgen.Tests/CasingGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/CasingGenerationTests.cs
@@ -31,10 +31,12 @@ namespace Bonsai.Sgen.Tests
         ""type"": ""object"",
         ""properties"": {
           ""bar"": {
-            ""type"": [
-              ""null"",
-              ""string""
-            ]
+            ""enum"": [
+               ""This is a string A"",
+               ""This is a string B""
+            ],
+            ""title"": ""StringEnum"",
+            ""type"": ""string""
           }
         }
       }
@@ -49,7 +51,8 @@ namespace Bonsai.Sgen.Tests
             var schema = await CreateTestSchema();
             var generator = TestHelper.CreateGenerator(schema);
             var code = generator.GenerateFile();
-            Assert.IsTrue(code.Contains("public ThingContainer BaseType"), "Incorrect casing for property name.");
+            Assert.IsTrue(code.Contains("public ThingContainer BaseType"), "Incorrect casing for property type or name.");
+            Assert.IsTrue(code.Contains("ThisIsAStringA = 0,"), "Incorrect casing for enum name.");
             CompilerTestHelper.CompileFromSource(code);
         }
     }

--- a/Bonsai.Sgen/CSharpCodeDomGeneratorSettings.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGeneratorSettings.cs
@@ -8,6 +8,9 @@ namespace Bonsai.Sgen
         {
             GenerateDataAnnotations = false;
             GenerateJsonMethods = true;
+            TypeNameGenerator = new CSharpTypeNameGenerator();
+            EnumNameGenerator = new CSharpEnumNameGenerator();
+            PropertyNameGenerator = new CSharpPropertyNameGenerator();
             JsonLibrary = CSharpJsonLibrary.NewtonsoftJson;
             ArrayInstanceType = "System.Collections.Generic.List";
             ArrayBaseType = "System.Collections.Generic.List";

--- a/Bonsai.Sgen/CSharpEnumNameGenerator.cs
+++ b/Bonsai.Sgen/CSharpEnumNameGenerator.cs
@@ -1,0 +1,17 @@
+﻿using NJsonSchema;
+using NJsonSchema.CodeGeneration;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Bonsai.Sgen
+{
+    internal class CSharpEnumNameGenerator : IEnumNameGenerator
+    {
+        readonly DefaultEnumNameGenerator defaultGenerator = new();
+
+        public string Generate(int index, string name, object value, JsonSchema schema)
+        {
+            var defaultName = defaultGenerator.Generate(index, name, value, schema);
+            return PascalCaseNamingConvention.Instance.Apply(defaultName);
+        }
+    }
+}

--- a/Bonsai.Sgen/CSharpPropertyNameGenerator.cs
+++ b/Bonsai.Sgen/CSharpPropertyNameGenerator.cs
@@ -1,0 +1,14 @@
+﻿using NJsonSchema;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Bonsai.Sgen
+{
+    internal class CSharpPropertyNameGenerator : NJsonSchema.CodeGeneration.CSharp.CSharpPropertyNameGenerator
+    {
+        public override string Generate(JsonSchemaProperty property)
+        {
+            var defaultName = base.Generate(property);
+            return PascalCaseNamingConvention.Instance.Apply(defaultName);
+        }
+    }
+}

--- a/Bonsai.Sgen/CSharpTypeNameGenerator.cs
+++ b/Bonsai.Sgen/CSharpTypeNameGenerator.cs
@@ -1,0 +1,14 @@
+﻿using NJsonSchema;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Bonsai.Sgen
+{
+    internal class CSharpTypeNameGenerator : DefaultTypeNameGenerator
+    {
+        protected override string Generate(JsonSchema schema, string typeNameHint)
+        {
+            var defaultName = base.Generate(schema, typeNameHint);
+            return PascalCaseNamingConvention.Instance.Apply(defaultName);
+        }
+    }
+}


### PR DESCRIPTION
NJsonSchema supports implementing name generator interfaces to control more specifically how the names for different entities are generated. This PR overrides the default name generators from NJsonSchema with the `PascalNamingConvention` implementation from YamlDotNet which supports full hyphen-case and snake_case conversions.

Fixes #26 