### PR TITLE
Fix naming convention edge cases

### DIFF
--- a/Bonsai.Sgen.Tests/CasingGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/CasingGenerationTests.cs
@@ -34,7 +34,8 @@ namespace Bonsai.Sgen.Tests
             ""enum"": [
                ""This is a string A"",
                ""This is a string B"",
-               ""snake_case_with_3_numbers""
+               ""snake_case_with_3_numbers"",
+               ""hyphen-case-with-3-numbers""
             ],
             ""title"": ""StringEnum"",
             ""type"": ""string""
@@ -47,7 +48,7 @@ namespace Bonsai.Sgen.Tests
         }
 
         [TestMethod]
-        public async Task GenerateFromSnakeCase_GeneratePascalCaseNames()
+        public async Task GenerateFromSnakeAndHyphenCase_GeneratePascalCaseNames()
         {
             var schema = await CreateTestSchema();
             var generator = TestHelper.CreateGenerator(schema);
@@ -55,6 +56,7 @@ namespace Bonsai.Sgen.Tests
             Assert.IsTrue(code.Contains("public ThingContainer BaseType"), "Incorrect casing for property type or name.");
             Assert.IsTrue(code.Contains("ThisIsAStringA = 0"), "Incorrect casing for enum name.");
             Assert.IsTrue(code.Contains("SnakeCaseWith3Numbers = 2"), "Incorrect casing for enum name.");
+            Assert.IsTrue(code.Contains("HyphenCaseWith3Numbers = 3"), "Incorrect casing for enum name.");
             CompilerTestHelper.CompileFromSource(code);
         }
     }

--- a/Bonsai.Sgen.Tests/CasingGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/CasingGenerationTests.cs
@@ -33,7 +33,8 @@ namespace Bonsai.Sgen.Tests
           ""bar"": {
             ""enum"": [
                ""This is a string A"",
-               ""This is a string B""
+               ""This is a string B"",
+               ""snake_case_with_3_numbers""
             ],
             ""title"": ""StringEnum"",
             ""type"": ""string""
@@ -52,7 +53,8 @@ namespace Bonsai.Sgen.Tests
             var generator = TestHelper.CreateGenerator(schema);
             var code = generator.GenerateFile();
             Assert.IsTrue(code.Contains("public ThingContainer BaseType"), "Incorrect casing for property type or name.");
-            Assert.IsTrue(code.Contains("ThisIsAStringA = 0,"), "Incorrect casing for enum name.");
+            Assert.IsTrue(code.Contains("ThisIsAStringA = 0"), "Incorrect casing for enum name.");
+            Assert.IsTrue(code.Contains("SnakeCaseWith3Numbers = 2"), "Incorrect casing for enum name.");
             CompilerTestHelper.CompileFromSource(code);
         }
     }

--- a/Bonsai.Sgen/CSharpEnumNameGenerator.cs
+++ b/Bonsai.Sgen/CSharpEnumNameGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using NJsonSchema;
 using NJsonSchema.CodeGeneration;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Bonsai.Sgen
 {
@@ -11,7 +10,7 @@ namespace Bonsai.Sgen
         public string Generate(int index, string name, object value, JsonSchema schema)
         {
             var defaultName = defaultGenerator.Generate(index, name, value, schema);
-            return PascalCaseNamingConvention.Instance.Apply(defaultName);
+            return CSharpNamingConvention.Instance.Apply(defaultName);
         }
     }
 }

--- a/Bonsai.Sgen/CSharpNamingConvention.cs
+++ b/Bonsai.Sgen/CSharpNamingConvention.cs
@@ -1,0 +1,19 @@
+﻿using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Bonsai.Sgen
+{
+    internal class CSharpNamingConvention : INamingConvention
+    {
+        public static readonly INamingConvention Instance = new CSharpNamingConvention();
+
+        private CSharpNamingConvention()
+        {
+        }
+
+        public string Apply(string value)
+        {
+            return PascalCaseNamingConvention.Instance.Apply(value).Replace("_", string.Empty);
+        }
+    }
+}

--- a/Bonsai.Sgen/CSharpPropertyNameGenerator.cs
+++ b/Bonsai.Sgen/CSharpPropertyNameGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using NJsonSchema;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Bonsai.Sgen
 {
@@ -8,7 +7,7 @@ namespace Bonsai.Sgen
         public override string Generate(JsonSchemaProperty property)
         {
             var defaultName = base.Generate(property);
-            return PascalCaseNamingConvention.Instance.Apply(defaultName);
+            return CSharpNamingConvention.Instance.Apply(defaultName);
         }
     }
 }

--- a/Bonsai.Sgen/CSharpTypeNameGenerator.cs
+++ b/Bonsai.Sgen/CSharpTypeNameGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using NJsonSchema;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Bonsai.Sgen
 {
@@ -8,7 +7,7 @@ namespace Bonsai.Sgen
         protected override string Generate(JsonSchema schema, string typeNameHint)
         {
             var defaultName = base.Generate(schema, typeNameHint);
-            return PascalCaseNamingConvention.Instance.Apply(defaultName);
+            return CSharpNamingConvention.Instance.Apply(defaultName);
         }
     }
 }


### PR DESCRIPTION
This PR fixes a few naming convention edge cases. Regression tests are added to make it easier to debug future naming convention issues.

Fixes #29 