### PR TITLE
Resolve oneOf discriminator references

### DIFF
--- a/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
@@ -285,6 +285,75 @@ namespace Bonsai.Sgen.Tests
         [DataRow(SerializerLibraries.YamlDotNet)]
         [DataRow(SerializerLibraries.NewtonsoftJson)]
         [DataRow(SerializerLibraries.NewtonsoftJson | SerializerLibraries.YamlDotNet)]
+        public async Task GenerateFromOneOfDiscriminatorRefSchemaProperty_SerializerAnnotationsDeclareKnownTypes(SerializerLibraries serializerLibraries)
+        {
+            var schema = await JsonSchema.FromJsonAsync(@"
+{
+  ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+  ""type"": ""object"",
+  ""title"": ""Container"",
+  ""properties"": {
+    ""Animal"": {
+      ""$ref"": ""#/definitions/Animal""
+    }
+  },
+  ""definitions"": {
+    ""Animal"": {
+      ""x-abstract"": true,
+      ""discriminator"": {
+        ""propertyName"": ""kind"",
+        ""mapping"": {
+          ""Dog"": ""#/definitions/Dog"",
+          ""Cat"": ""#/definitions/Cat""
+        }
+      },
+      ""oneOf"": [
+        {
+          ""$ref"": ""#/definitions/Dog""
+        },
+        {
+          ""$ref"": ""#/definitions/Cat""
+        },
+        {
+          ""type"": ""null""
+        }
+      ]
+    },
+    ""Dog"": {
+      ""type"": ""object"",
+      ""properties"": {
+        ""kind"": {
+          ""enum"": [ ""Dog"" ]
+        }
+      },
+      ""required"": [ ""kind"" ]
+    },
+    ""Cat"": {
+      ""type"": ""object"",
+      ""properties"": {
+        ""kind"": {
+          ""enum"": [ ""Cat"" ]
+        }
+      },
+      ""required"": [ ""kind"" ]
+    }
+  }
+}
+");
+            var generator = TestHelper.CreateGenerator(schema, serializerLibraries);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("class Dog : Animal"), "Derived types do not inherit from base type.");
+            Assert.IsTrue(!code.Contains("public enum DogKind"), "Discriminator property is repeated in derived types.");
+            Assert.IsTrue(code.Contains("Animal Animal"), "Container element type does not match base type.");
+            Assert.IsTrue(code.Contains("[JsonInheritanceAttribute(\"Dog\", typeof(Dog))]"));
+            AssertDiscriminatorAttribute(code, serializerLibraries, "kind");
+            CompilerTestHelper.CompileFromSource(code);
+        }
+
+        [TestMethod]
+        [DataRow(SerializerLibraries.YamlDotNet)]
+        [DataRow(SerializerLibraries.NewtonsoftJson)]
+        [DataRow(SerializerLibraries.NewtonsoftJson | SerializerLibraries.YamlDotNet)]
         public async Task GenerateFromArrayItemDiscriminator_EnsureFallbackDiscriminatorBaseTypeName(SerializerLibraries serializerLibraries)
         {
             var schema = await JsonSchema.FromJsonAsync(@"

--- a/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
@@ -418,5 +418,75 @@ namespace Bonsai.Sgen.Tests
             AssertDiscriminatorAttribute(code, serializerLibraries, "kind");
             CompilerTestHelper.CompileFromSource(code);
         }
+
+        [TestMethod]
+        [DataRow(SerializerLibraries.YamlDotNet)]
+        [DataRow(SerializerLibraries.NewtonsoftJson)]
+        [DataRow(SerializerLibraries.NewtonsoftJson | SerializerLibraries.YamlDotNet)]
+        public async Task GenerateFromArrayItemDiscriminatorRef_EnsureFallbackDiscriminatorBaseTypeName(SerializerLibraries serializerLibraries)
+        {
+            var schema = await JsonSchema.FromJsonAsync(@"
+{
+  ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+  ""type"": ""object"",
+  ""title"": ""Container"",
+  ""properties"": {
+    ""Animals"": {
+      ""type"": ""array"",
+      ""items"": { ""$ref"": ""#/definitions/Animal"" }
+    }
+  },
+  ""definitions"": {
+    ""Animal"": {
+        ""x-abstract"": true,
+        ""discriminator"": {
+          ""propertyName"": ""kind"",
+          ""mapping"": {
+              ""Dog"": ""#/definitions/Dog"",
+              ""Cat"": ""#/definitions/Cat""
+          }
+        },
+        ""oneOf"": [
+          {
+            ""$ref"": ""#/definitions/Dog""
+          },
+          {
+            ""$ref"": ""#/definitions/Cat""
+          },
+          {
+            ""type"": ""null""
+          }
+        ]
+    },
+    ""Dog"": {
+      ""type"": ""object"",
+      ""properties"": {
+        ""kind"": {
+          ""enum"": [ ""Dog"" ]
+        }
+      },
+      ""required"": [ ""kind"" ]
+    },
+    ""Cat"": {
+      ""type"": ""object"",
+      ""properties"": {
+        ""kind"": {
+          ""enum"": [ ""Cat"" ]
+        }
+      },
+      ""required"": [ ""kind"" ]
+    }
+  }
+}
+");
+            var generator = TestHelper.CreateGenerator(schema, serializerLibraries);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("class Dog : Animal"), "Derived types do not inherit from base type.");
+            Assert.IsTrue(!code.Contains("public enum DogKind"), "Discriminator property is repeated in derived types.");
+            Assert.IsTrue(code.Contains("List<Animal> Animal"), "Container element type does not match base type.");
+            Assert.IsTrue(code.Contains("[JsonInheritanceAttribute(\"Dog\", typeof(Dog))]"));
+            AssertDiscriminatorAttribute(code, serializerLibraries, "kind");
+            CompilerTestHelper.CompileFromSource(code);
+        }
     }
 }

--- a/Bonsai.Sgen.Tests/SchemaTestHelper.cs
+++ b/Bonsai.Sgen.Tests/SchemaTestHelper.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using NJsonSchema;
+
+namespace Bonsai.Sgen.Tests
+{
+    static class SchemaTestHelper
+    {
+        public static JsonSchema CreateContainerSchema(IEnumerable<KeyValuePair<string, JsonSchema>> definitions)
+        {
+            var result = new JsonSchema
+            {
+                Type = JsonObjectType.Object,
+                Title = "Container"
+            };
+            foreach (var definition in definitions)
+            {
+                result.Definitions.Add(definition);
+            }
+            return result;
+        }
+
+        public static void AddRange(this ICollection<JsonSchema> collection, IEnumerable<JsonSchema> schemas)
+        {
+            foreach (var schema in schemas)
+            {
+                collection.Add(schema);
+            }
+        }
+
+        public static JsonSchema CreateNullSchema() => new() { Type = JsonObjectType.Null };
+
+        public static JsonSchema CreateOneOfSchema(IEnumerable<JsonSchema> schemas, bool optional = true)
+        {
+            var schema = new JsonSchema();
+            schema.OneOf.AddRange(schemas);
+            if (optional)
+            {
+                schema.OneOf.Add(CreateNullSchema());
+            }
+            return schema;
+        }
+
+        public static JsonSchema CreateDiscriminatorSchema(
+            string propertyName = "kind",
+            params KeyValuePair<string, JsonSchema>[] mappings)
+        {
+            return CreateDiscriminatorSchema<JsonSchema>(propertyName, mappings);
+        }
+
+        public static TSchemaType CreateDiscriminatorSchema<TSchemaType>(
+            string propertyName = "kind",
+            params KeyValuePair<string, JsonSchema>[] mappings)
+            where TSchemaType : JsonSchema, new()
+        {
+            var discriminator = new OpenApiDiscriminator { PropertyName = propertyName };
+            var result = new TSchemaType()
+            {
+                IsAbstract = true,
+                DiscriminatorObject = discriminator
+            };
+
+            if (mappings.Length > 0)
+            {
+                for (int i = 0; i < mappings.Length; i++)
+                {
+                    discriminator.Mapping.Add(mappings[i]);
+                    result.OneOf.Add(new JsonSchema { Reference = mappings[i].Value });
+                }
+
+                result.OneOf.Add(new JsonSchema { Type = JsonObjectType.Null });
+            }
+            return result;
+        }
+
+        public static KeyValuePair<string, JsonSchema>[] CreateDerivedSchemas(string propertyName, params string[] keys)
+        {
+            return CreateDerivedSchemas(propertyName, baseSchema: null, keys);
+        }
+
+        public static KeyValuePair<string, JsonSchema>[] CreateDerivedSchemas(string propertyName, JsonSchema baseSchema, params string[] keys)
+        {
+            return Array.ConvertAll(keys, key =>
+            {
+                var schema = new JsonSchema()
+                {
+                    Type = JsonObjectType.Object,
+                    RequiredProperties = { propertyName },
+                    Properties =
+                    {
+                        { propertyName, new JsonSchemaProperty { Enumeration = { key } } }
+                    }
+                };
+                if (baseSchema != null) schema.AllOf.Add(baseSchema);
+                return new KeyValuePair<string, JsonSchema>(key, schema);
+            });
+        }
+    }
+}


### PR DESCRIPTION
This PR ensures that `oneOf` inheritance is resolved into `allOf` inheritance both for inline and reference schemas. Unit tests were refactored to test a wider range of discriminator patterns, including both single property and collections. Type name hinting was expanded to include more reasonable fallbacks for collections.

Fixes #33