### PR TITLE
Keep leading underscores in generated identifiers

### DIFF
--- a/Bonsai.Sgen.Tests/EnumGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/EnumGenerationTests.cs
@@ -37,6 +37,33 @@ namespace Bonsai.Sgen.Tests
         }
 
         [TestMethod]
+        public async Task GenerateIntegerEnumWithRawLiterals_EnumTypeUseValidIdentifiers()
+        {
+            var schema = await JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""type"": ""object"",
+    ""title"": ""Container"",
+    ""additionalProperties"": false,
+    ""properties"": {
+      ""Enum"": {
+         ""$ref"": ""#/definitions/IntEnum""
+      }
+    },
+    ""definitions"": {
+      ""IntEnum"": {
+         ""enum"": [ 0, 1, 2 ],
+         ""type"": ""integer""
+      }
+    }
+  }
+");
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            CompilerTestHelper.CompileFromSource(code);
+        }
+
+        [TestMethod]
         public void GenerateStringEnum_SerializerAnnotationsUseStringValues()
         {
             var schema = JsonSchema.FromType<Foo>();

--- a/Bonsai.Sgen/CSharpNamingConvention.cs
+++ b/Bonsai.Sgen/CSharpNamingConvention.cs
@@ -13,7 +13,9 @@ namespace Bonsai.Sgen
 
         public string Apply(string value)
         {
-            return PascalCaseNamingConvention.Instance.Apply(value).Replace("_", string.Empty);
+            var result = PascalCaseNamingConvention.Instance.Apply(value);
+            var prefix = result.StartsWith('_') ? "_" : string.Empty;
+            return prefix + result.Replace("_", string.Empty);
         }
     }
 }


### PR DESCRIPTION
This PR ensures that leading underscores in identifier names are kept in the naming convention, which fixes a relevant edge case when generating enum classes for raw string literals.

Fix #32 