### PR TITLE
Add support for deep oneOf inheritance

### DIFF
--- a/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
@@ -215,7 +215,7 @@ namespace Bonsai.Sgen.Tests
             var code = generator.GenerateFile();
             Assert.IsTrue(code.Contains("class Dog : Animal"), "Derived types do not inherit from base type.");
             Assert.IsTrue(!code.Contains("public enum DogKind"), "Discriminator property is repeated in derived types.");
-            Assert.IsTrue(code.Contains("List<Animal> Animal"), "Container element type does not match base type.");
+            Assert.IsTrue(code.Contains("List<Animal> Animals"), "Container element type does not match base type.");
             Assert.IsTrue(code.Contains("[JsonInheritanceAttribute(\"Dog\", typeof(Dog))]"));
             AssertDiscriminatorAttribute(code, serializerLibraries, "kind");
             CompilerTestHelper.CompileFromSource(code);

--- a/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NJsonSchema;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -217,6 +218,45 @@ namespace Bonsai.Sgen.Tests
             Assert.IsTrue(code.Contains("List<Animal> Animal"), "Container element type does not match base type.");
             Assert.IsTrue(code.Contains("[JsonInheritanceAttribute(\"Dog\", typeof(Dog))]"));
             AssertDiscriminatorAttribute(code, serializerLibraries, "kind");
+            CompilerTestHelper.CompileFromSource(code);
+        }
+
+        [TestMethod]
+        [DataRow(SerializerLibraries.YamlDotNet)]
+        [DataRow(SerializerLibraries.NewtonsoftJson)]
+        [DataRow(SerializerLibraries.NewtonsoftJson | SerializerLibraries.YamlDotNet)]
+        public void GenerateFromSubDiscriminatorSchemas_InheritanceHierarchyIsPreserved(SerializerLibraries serializerLibraries)
+        {
+            var subTypeSchemas = SchemaTestHelper.CreateDerivedSchemas("fur", "long", "short");
+            var subDiscriminator = SchemaTestHelper.CreateDiscriminatorSchema("fur", subTypeSchemas);
+            var derivedSchemas = SchemaTestHelper.CreateDerivedSchemas("type", "cat", "dog");
+            derivedSchemas[0].Value.DiscriminatorObject = subDiscriminator.DiscriminatorObject;
+            foreach (var subSchema in subDiscriminator.OneOf)
+            {
+                derivedSchemas[0].Value.OneOf.Add(subSchema);
+            }
+            var discriminator = SchemaTestHelper.CreateDiscriminatorSchema("type", derivedSchemas);
+            var schema = SchemaTestHelper.CreateContainerSchema(new Dictionary<string, JsonSchema>
+            {
+                { "LongFurCat", subTypeSchemas[0].Value },
+                { "Cat", derivedSchemas[0].Value },
+                { "Dog", derivedSchemas[1].Value },
+                { "Animal", discriminator },
+                { "ShortFurCat", subTypeSchemas[1].Value }
+            });
+            schema.Properties.Add("Animals", new()
+            {
+                Type = JsonObjectType.Array,
+                Item = new() { Reference = discriminator }
+            });
+
+            var generator = TestHelper.CreateGenerator(schema, serializerLibraries);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("class Cat : Animal"), "Derived types do not inherit from base type.");
+            Assert.IsTrue(!code.Contains("public enum LongFurCatFur"), "Discriminator property is repeated in derived types.");
+            Assert.IsTrue(code.Contains("List<Animal> Animals"), "Container element type does not match base type.");
+            Assert.IsTrue(code.Contains("[JsonInheritanceAttribute(\"dog\", typeof(Dog))]"));
+            AssertDiscriminatorAttribute(code, serializerLibraries, "type");
             CompilerTestHelper.CompileFromSource(code);
         }
     }

--- a/Bonsai.Sgen.Tests/TestHelper.cs
+++ b/Bonsai.Sgen.Tests/TestHelper.cs
@@ -8,7 +8,7 @@ namespace Bonsai.Sgen.Tests
             JsonSchema schema,
             SerializerLibraries serializerLibraries = SerializerLibraries.YamlDotNet | SerializerLibraries.NewtonsoftJson)
         {
-            schema = schema.WithUniqueDiscriminatorProperties();
+            schema = schema.WithResolvedDiscriminatorInheritance();
             var settings = new CSharpCodeDomGeneratorSettings
             {
                 Namespace = nameof(TestHelper),

--- a/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Text;
 using System.Xml.Serialization;
 using Newtonsoft.Json;
+using NJsonSchema;
 using NJsonSchema.Converters;
 using YamlDotNet.Serialization;
 
@@ -30,7 +31,7 @@ namespace Bonsai.Sgen
             var jsonSerializer = Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson);
             var yamlSerializer = Settings.SerializerLibraries.HasFlag(SerializerLibraries.YamlDotNet);
             if (Model.IsAbstract) type.TypeAttributes |= System.Reflection.TypeAttributes.Abstract;
-            if (Model.HasDiscriminator)
+            if (Model.Schema.DiscriminatorObject is OpenApiDiscriminator discriminator)
             {
                 if (jsonSerializer || yamlSerializer)
                 {
@@ -39,13 +40,13 @@ namespace Bonsai.Sgen
                         type.CustomAttributes.Add(new CodeAttributeDeclaration(
                             new CodeTypeReference(typeof(JsonConverter)),
                             new CodeAttributeArgument(new CodeTypeOfExpression(nameof(JsonInheritanceConverter))),
-                            new CodeAttributeArgument(new CodePrimitiveExpression(Model.Discriminator))));
+                            new CodeAttributeArgument(new CodePrimitiveExpression(discriminator.PropertyName))));
                     }
                     if (yamlSerializer)
                     {
                         type.CustomAttributes.Add(new CodeAttributeDeclaration(
                             new CodeTypeReference("YamlDiscriminator"),
-                            new CodeAttributeArgument(new CodePrimitiveExpression(Model.Discriminator))));
+                            new CodeAttributeArgument(new CodePrimitiveExpression(discriminator.PropertyName))));
                     }
 
                     foreach (var derivedModel in Model.DerivedClasses)

--- a/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -105,7 +105,7 @@ namespace Bonsai.Sgen
                               let classType = type as CSharpClassCodeArtifact
                               where classType != null
                               select classType).ToList();
-            var discriminatorTypes = classTypes.Where(modelType => modelType.Model.HasDiscriminator).ToList();
+            var discriminatorTypes = classTypes.Where(modelType => modelType.Model.Schema.DiscriminatorObject != null).ToList();
             foreach (var type in discriminatorTypes)
             {
                 var matchTemplate = new CSharpTypeMatchTemplate(type, _provider, _options, Settings);

--- a/Bonsai.Sgen/CSharpTypeResolver.cs
+++ b/Bonsai.Sgen/CSharpTypeResolver.cs
@@ -12,11 +12,6 @@ namespace Bonsai.Sgen
         {
         }
 
-        public CSharpTypeResolver(CSharpGeneratorSettings settings, JsonSchema exceptionSchema)
-            : base(settings, exceptionSchema)
-        {
-        }
-
         public override JsonSchema RemoveNullability(JsonSchema schema)
         {
             JsonSchema? selectedSchema = null;

--- a/Bonsai.Sgen/Program.cs
+++ b/Bonsai.Sgen/Program.cs
@@ -63,7 +63,7 @@ namespace Bonsai.Sgen
                     SerializerLibraries = serializerLibraries
                 };
 
-                schema = schema.WithUniqueDiscriminatorProperties();
+                schema = schema.WithResolvedDiscriminatorInheritance();
                 var generator = new CSharpCodeDomGenerator(schema, settings);
                 var code = generator.GenerateFile(generatorTypeName);
                 if (string.IsNullOrEmpty(outputFilePath))


### PR DESCRIPTION
This PR expands discriminator inheritance resolution to support deep inheritance hierarchies. It also resolves several complicated assumptions found in NJsonSchema that would limit future support for complex inheritance schemes.

The core of the approach is to resolve `oneOf` inheritance in two passes:
1. for each discriminator schema:
  a. if schema is inline, move the discriminator to a separate type definition
  b. if the discriminator has `oneOf` declarations, inject the discriminator as `allOf` schema in each of the derived schemas
2. remove discriminator properties from all derived schemas

A simple regression test for a deep inheritance schema is added, but more extensive tests will be required in the future to ensure all edge cases are covered.