### PR TITLE
Allow specifying the schema path as a URL

### DIFF
--- a/Bonsai.Sgen/Bonsai.Sgen.csproj
+++ b/Bonsai.Sgen/Bonsai.Sgen.csproj
@@ -5,7 +5,8 @@
     <PackageId>Bonsai.Sgen</PackageId>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Bonsai.Sgen/Program.cs
+++ b/Bonsai.Sgen/Program.cs
@@ -9,7 +9,8 @@ namespace Bonsai.Sgen
         {
             var schemaPath = new Option<FileInfo>(
                 name: "--schema",
-                description: "Generates serialization classes for data types in the specified schema file.")
+                description: "Specifies the URL or path to the JSON schema describing the data types " +
+                             "for which to generate serialization classes.")
                 { IsRequired = !Console.IsInputRedirected };
             var generatorNamespace = new Option<string?>(
                 name: "--namespace",
@@ -42,7 +43,7 @@ namespace Bonsai.Sgen
             rootCommand.AddOption(generatorTypeName);
             rootCommand.AddOption(outputPath);
             rootCommand.AddOption(serializerLibraries);
-            rootCommand.SetHandler(async (filePath, generatorNamespace, generatorTypeName, outputFilePath, serializerLibraries) =>
+            rootCommand.SetHandler(async (schemaPath, generatorNamespace, generatorTypeName, outputFilePath, serializerLibraries) =>
             {
                 JsonSchema schema;
                 if (Console.IsInputRedirected)
@@ -52,7 +53,9 @@ namespace Bonsai.Sgen
                 }
                 else
                 {
-                    schema = await JsonSchema.FromFileAsync(filePath.FullName);
+                    schema = Uri.IsWellFormedUriString(schemaPath.FullName, UriKind.Absolute)
+                        ? await JsonSchema.FromUrlAsync(schemaPath.FullName)
+                        : await JsonSchema.FromFileAsync(schemaPath.FullName);
                 }
 
                 if (string.IsNullOrEmpty(generatorTypeName))


### PR DESCRIPTION
This PR extends the `--schema` option to allow specifying the schema path as a URL. This will allow generating serialization resources from online hosted schemas.