### PR TITLE
Ensure generated attribute honors nullable & required properties

### DIFF
--- a/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -121,7 +121,7 @@ namespace Bonsai.Sgen
                             nameof(JsonPropertyAttribute.Required),
                             new CodeFieldReferenceExpression(
                                 new CodeTypeReferenceExpression(typeof(Required)),
-                                nameof(Required.Always))));
+                                property.IsNullable ? nameof(Required.AllowNull) : nameof(Required.Always))));
                     }
                     propertyDeclaration.CustomAttributes.Add(jsonProperty);
                 }


### PR DESCRIPTION
This PR tries to fix #46 by modifying the `Required` flag depending on whether the property is nullable or not. It should be noted that this fix is only addressing the JSON generator. I couldn't find documentation on the YAML attributes after looking into the currently used library.