### PR TITLE
Allow resolving schema references using $defs keyword

### DIFF
--- a/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/DiscriminatorGenerationTests.cs
@@ -41,7 +41,7 @@ namespace Bonsai.Sgen.Tests
       ""Animal"": {
         ""oneOf"": [
           {
-            ""$ref"": ""#/definitions/Animal""
+            ""$ref"": ""#/$defs/Animal""
           },
           {
             ""type"": ""null""
@@ -49,7 +49,7 @@ namespace Bonsai.Sgen.Tests
         ]
       }
     },
-    ""definitions"": {
+    ""$defs"": {
       ""Dog"": {
         ""type"": ""object"",
         ""additionalProperties"": false,
@@ -63,7 +63,7 @@ namespace Bonsai.Sgen.Tests
         },
         ""allOf"": [
           {
-            ""$ref"": ""#/definitions/Animal""
+            ""$ref"": ""#/$defs/Animal""
           }
         ]
       },
@@ -72,7 +72,7 @@ namespace Bonsai.Sgen.Tests
         ""discriminator"": {
           ""propertyName"": ""discriminator"",
           ""mapping"": {
-              ""DogType"": ""#/definitions/Dog""
+              ""DogType"": ""#/$defs/Dog""
           }
         },
         ""x-abstract"": true,

--- a/Bonsai.Sgen.Tests/TestHelper.cs
+++ b/Bonsai.Sgen.Tests/TestHelper.cs
@@ -8,12 +8,13 @@ namespace Bonsai.Sgen.Tests
             JsonSchema schema,
             SerializerLibraries serializerLibraries = SerializerLibraries.YamlDotNet | SerializerLibraries.NewtonsoftJson)
         {
-            schema = schema.WithResolvedDiscriminatorInheritance();
             var settings = new CSharpCodeDomGeneratorSettings
             {
                 Namespace = nameof(TestHelper),
                 SerializerLibraries = serializerLibraries
             };
+            schema = schema.WithCompatibleDefinitions(settings.TypeNameGenerator)
+                           .WithResolvedDiscriminatorInheritance();
 
             return new CSharpCodeDomGenerator(schema, settings);
         }

--- a/Bonsai.Sgen/Program.cs
+++ b/Bonsai.Sgen/Program.cs
@@ -63,7 +63,8 @@ namespace Bonsai.Sgen
                     SerializerLibraries = serializerLibraries
                 };
 
-                schema = schema.WithResolvedDiscriminatorInheritance();
+                schema = schema.WithCompatibleDefinitions(settings.TypeNameGenerator)
+                               .WithResolvedDiscriminatorInheritance();
                 var generator = new CSharpCodeDomGenerator(schema, settings);
                 var code = generator.GenerateFile(generatorTypeName);
                 if (string.IsNullOrEmpty(outputFilePath))


### PR DESCRIPTION
Modern JSON schema uses `$defs` as a standard keyword in schema reference paths. This is unfortunately not yet supported by NJsonSchema (see https://github.com/RicoSuter/NJsonSchema/issues/1536).

As a workaround this PR proposes to resolve the problem by implementing a custom `JsonSchemaVisitor` to add definitions created using `$defs` to the schema.