### PR TITLE
Allow recursive assignment of default values to complex properties

### DIFF
--- a/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
@@ -54,7 +54,7 @@ namespace Bonsai.Sgen.Tests
 ");
             var generator = TestHelper.CreateGenerator(schema);
             var code = generator.GenerateFile();
-            Assert.IsTrue(code.Contains("private string _name = \"default_name\""), "Missing field initializer.");
+            Assert.IsTrue(code.Contains("_name = \"default_name\""), "Missing field initializer.");
             CompilerTestHelper.CompileFromSource(code);
         }
 

--- a/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema;
+
+namespace Bonsai.Sgen.Tests
+{
+    [TestClass]
+    public class PropertyGenerationTests
+    {
+        [TestMethod]
+        public async Task GenerateFromRequiredNullableProperty_EnsurePropertyAnnotation()
+        {
+            var schema = await JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""type"": ""object"",
+    ""title"": ""Container"",
+    ""properties"": {
+      ""name"": {
+        ""oneOf"": [
+          {
+            ""type"": ""string""
+          },
+          {
+            ""type"": ""null""
+          }
+        ]
+      }
+    },
+    ""required"": [""name""]
+}
+");
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("Required=Newtonsoft.Json.Required.AllowNull"), "Missing property annotation.");
+            CompilerTestHelper.CompileFromSource(code);
+        }
+    }
+}

--- a/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
@@ -37,7 +37,7 @@ namespace Bonsai.Sgen.Tests
         }
 
         [TestMethod]
-        public async Task GenerateFromPropertyDefault_EnsureFieldInitializer()
+        public async Task GenerateFromSimplePropertyDefault_EnsureDefaultInitializer()
         {
             var schema = await JsonSchema.FromJsonAsync(@"
 {
@@ -55,6 +55,28 @@ namespace Bonsai.Sgen.Tests
             var generator = TestHelper.CreateGenerator(schema);
             var code = generator.GenerateFile();
             Assert.IsTrue(code.Contains("private string _name = \"default_name\""), "Missing field initializer.");
+            CompilerTestHelper.CompileFromSource(code);
+        }
+
+        [TestMethod]
+        public async Task GenerateFromArrayProperty_EnsureDefaultInitializer()
+        {
+            var schema = await JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""type"": ""object"",
+    ""title"": ""Container"",
+    ""properties"": {
+      ""items"": {
+        ""type"": ""array"",
+        ""items"": { ""type"": ""string"" }
+      }
+    }
+}
+");
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("_items = new System.Collections.Generic.List<string>();"), "Missing field initializer.");
             CompilerTestHelper.CompileFromSource(code);
         }
     }

--- a/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
@@ -79,5 +79,72 @@ namespace Bonsai.Sgen.Tests
             Assert.IsTrue(code.Contains("_items = new System.Collections.Generic.List<string>();"), "Missing field initializer.");
             CompilerTestHelper.CompileFromSource(code);
         }
+
+        [TestMethod]
+        public async Task GenerateFromComplexPropertyDefault_EnsureFieldInitializer()
+        {
+            var schema = await JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""type"": ""object"",
+    ""title"": ""Container"",
+    ""definitions"": {
+      ""Bar"": {
+        ""properties"": {
+          ""value"": {
+            ""default"": 1,
+            ""type"": ""integer""
+          },
+          ""label"": {
+            ""default"": ""default"",
+            ""type"": ""string""
+          }
+        },
+        ""title"": ""Bar"",
+        ""type"": ""object""
+      },
+      ""Foo"": {
+        ""properties"": {
+          ""foo_label"": {
+            ""default"": ""foo_default_label"",
+            ""type"": ""string""
+          },
+          ""bar_with_default"": {
+            ""allOf"": [{
+              ""$ref"": ""#/definitions/Bar""
+            }],
+            ""default"": {
+              ""value"": 0,
+              ""label"": ""foo_default""
+            }
+          }
+        },
+        ""title"": ""Foo"",
+        ""type"": ""object""
+      }
+    },
+    ""properties"": {
+      ""foo_with_default"": {
+        ""allOf"": [{
+          ""$ref"": ""#/definitions/Foo""
+        }],
+        ""default"": {
+          ""foo_label"": ""foo_default_label"",
+          ""bar_with_default"": {
+            ""label"": ""top_default"",
+            ""value"": 2
+          }
+        }
+      }
+    }
+}
+");
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("_barWithDefault.Label = \"foo_default\""));
+            Assert.IsTrue(code.Contains("_fooWithDefault.BarWithDefault.Value = 2"));
+            Assert.IsTrue(code.Contains("_fooWithDefault.BarWithDefault.Label = \"top_default\""));
+            CompilerTestHelper.CompileFromSource(code);
+        }
     }
 }

--- a/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
@@ -35,5 +35,27 @@ namespace Bonsai.Sgen.Tests
             Assert.IsTrue(code.Contains("Required=Newtonsoft.Json.Required.AllowNull"), "Missing property annotation.");
             CompilerTestHelper.CompileFromSource(code);
         }
+
+        [TestMethod]
+        public async Task GenerateFromPropertyDefault_EnsureFieldInitializer()
+        {
+            var schema = await JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""type"": ""object"",
+    ""title"": ""Container"",
+    ""properties"": {
+      ""name"": {
+        ""default"": ""default_name"",
+        ""type"": ""string""
+      }
+    }
+}
+");
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("private string _name = \"default_name\""), "Missing field initializer.");
+            CompilerTestHelper.CompileFromSource(code);
+        }
     }
 }

--- a/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -70,6 +70,7 @@ namespace Bonsai.Sgen
             }
 
             var propertyCount = 0;
+            var defaultConstructor = new CodeConstructor { Attributes = Model.IsAbstract ? MemberAttributes.Family : MemberAttributes.Public };
             foreach (var property in Model.Properties)
             {
                 propertyCount++;
@@ -80,11 +81,15 @@ namespace Bonsai.Sgen
                     property.FieldName);
                 if (property.HasDefaultValue)
                 {
-                    fieldDeclaration.InitExpression = new CodeSnippetExpression(property.DefaultValue);
+                    defaultConstructor.Statements.Add(new CodeAssignStatement(
+                        new CodeVariableReferenceExpression(property.FieldName),
+                        new CodeSnippetExpression(property.DefaultValue)));
                 }
                 else if (propertySchema?.IsArray is true)
                 {
-                    fieldDeclaration.InitExpression = new CodeObjectCreateExpression(fieldDeclaration.Type);
+                    defaultConstructor.Statements.Add(new CodeAssignStatement(
+                        new CodeVariableReferenceExpression(property.FieldName),
+                        new CodeObjectCreateExpression(fieldDeclaration.Type)));
                 }
 
                 var propertyDeclaration = new CodeMemberProperty
@@ -148,7 +153,6 @@ namespace Bonsai.Sgen
                 type.Members.Add(propertyDeclaration);
             }
 
-            var defaultConstructor = new CodeConstructor { Attributes = Model.IsAbstract ? MemberAttributes.Family : MemberAttributes.Public };
             var copyConstructor = new CodeConstructor { Attributes = MemberAttributes.Family };
             var copyParameter = new CodeParameterDeclarationExpression(Model.ClassName, "other");
             copyConstructor.Parameters.Add(copyParameter);

--- a/Bonsai.Sgen/CSharpClassTemplateModel.cs
+++ b/Bonsai.Sgen/CSharpClassTemplateModel.cs
@@ -15,8 +15,11 @@ namespace Bonsai.Sgen
             : base(typeName, settings, resolver, schema, rootObject)
         {
             Schema = schema;
+            Resolver = resolver;
         }
 
         public JsonSchema Schema { get; }
+
+        public CSharpTypeResolver Resolver { get; }
     }
 }


### PR DESCRIPTION
Although not strictly mandated by JSON-schema, it is common practice that property default values support arbitrarily nested JSON objects. This PR rearranges the default constructor code generator to support recursive assignment of default values in cases where the default value is an arbitrary JSON object.

It does this by piggybacking on provided JSON schema definitions for the model object properties, and abusing the `ValueGenerator.GetDefaultValue` to obtain valid code snippets for primitive property assignments.

Fixes #41 