### PR TITLE
Allow annotating schema type as external reference

### DIFF
--- a/Bonsai.Sgen.Tests/CompilerTestHelper.cs
+++ b/Bonsai.Sgen.Tests/CompilerTestHelper.cs
@@ -10,10 +10,10 @@ namespace Bonsai.Sgen.Tests
 {
     internal static class CompilerTestHelper
     {
-        public static void CompileFromSource(string code)
+        public static void CompileFromSource(params string[] code)
         {
             var options = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp5);
-            var syntaxTree = CSharpSyntaxTree.ParseText(code, options);
+            var syntaxTrees = Array.ConvertAll(code, text => CSharpSyntaxTree.ParseText(text, options));
             var serializerDependencies = new[]
             {
                 typeof(YamlDotNet.Core.Parser).Assembly.Location,
@@ -26,7 +26,7 @@ namespace Bonsai.Sgen.Tests
 
             var compilation = CSharpCompilation.Create(
                 nameof(CompilerTestHelper),
-                syntaxTrees: new[] { syntaxTree },
+                syntaxTrees: syntaxTrees,
                 references: assemblyReferences,
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
             using var memoryStream = new MemoryStream();

--- a/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
+++ b/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NJsonSchema;
+
+namespace Bonsai.Sgen.Tests
+{
+    [TestClass]
+    public class ExternalTypeGenerationTests
+    {
+        private static async Task<JsonSchema> CreateCommonDefinitions()
+        {
+            return await JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""definitions"": {
+      ""CommonType"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""Bar"": {
+            ""type"": ""integer""
+          }
+        }
+      }
+    }
+  }
+");
+        }
+
+        [TestMethod]
+        public void GenerateWithEmptyDefinitions_EmitEmptyCodeBlock()
+        {
+            var schema = new JsonSchema();
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            CompilerTestHelper.CompileFromSource(code);
+        }
+
+        [TestMethod]
+        public async Task GenerateWithDefinitionsOnly_EmitDefinitionTypes()
+        {
+            var schema = await CreateCommonDefinitions();
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            CompilerTestHelper.CompileFromSource(code);
+        }
+    }
+}

--- a/Bonsai.Sgen.Tests/TestHelper.cs
+++ b/Bonsai.Sgen.Tests/TestHelper.cs
@@ -6,11 +6,12 @@ namespace Bonsai.Sgen.Tests
     {
         public static CSharpCodeDomGenerator CreateGenerator(
             JsonSchema schema,
-            SerializerLibraries serializerLibraries = SerializerLibraries.YamlDotNet | SerializerLibraries.NewtonsoftJson)
+            SerializerLibraries serializerLibraries = SerializerLibraries.YamlDotNet | SerializerLibraries.NewtonsoftJson,
+            string schemaNamespace = nameof(TestHelper))
         {
             var settings = new CSharpCodeDomGeneratorSettings
             {
-                Namespace = nameof(TestHelper),
+                Namespace = schemaNamespace,
                 SerializerLibraries = serializerLibraries
             };
             schema = schema.WithCompatibleDefinitions(settings.TypeNameGenerator)

--- a/Bonsai.Sgen.Tests/TestJsonReferenceResolver.cs
+++ b/Bonsai.Sgen.Tests/TestJsonReferenceResolver.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NJsonSchema;
+using NJsonSchema.References;
+using NJsonSchema.Visitors;
+
+namespace Bonsai.Sgen.Tests
+{
+    internal class TestJsonReferenceResolver : JsonReferenceResolver
+    {
+        readonly IJsonReference _jsonReference;
+        readonly IDictionary<string, JsonSchema> _definitions;
+
+        public TestJsonReferenceResolver(JsonSchemaAppender schemaAppender, JsonSchema schema, string ns)
+            : base(schemaAppender)
+        {
+            _jsonReference = schema;
+            _definitions = schema.Definitions;
+            new ReferenceSchemaVisitor(ns).Visit(_jsonReference);
+        }
+
+        private IJsonReference ResolveLocalReference(string path)
+        {
+            var typeName = Path.GetFileName(path);
+            return _definitions[typeName];
+        }
+
+        public override Task<IJsonReference> ResolveFileReferenceAsync(string filePath, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ResolveLocalReference(filePath));
+        }
+
+        public override Task<IJsonReference> ResolveUrlReferenceAsync(string url, CancellationToken cancellationToken = default)
+        {
+            var referencePath = new Uri(url).LocalPath;
+            return Task.FromResult(ResolveLocalReference(referencePath));
+        }
+
+        class ReferenceSchemaVisitor : JsonSchemaVisitorBase
+        {
+            readonly string _namespace;
+
+            public ReferenceSchemaVisitor(string ns)
+            {
+                _namespace = ns;
+            }
+
+            protected override JsonSchema VisitSchema(JsonSchema schema, string path, string typeNameHint)
+            {
+                if (!string.IsNullOrEmpty(typeNameHint))
+                {
+                    schema.ExtensionData ??= new Dictionary<string, object>();
+                    schema.ExtensionData[JsonSchemaExtensions.TypeNameAnnotation] = $"{_namespace}.{typeNameHint}";
+                }
+                return schema;
+            }
+        }
+    }
+}

--- a/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -80,6 +80,9 @@ namespace Bonsai.Sgen
 
         public override IEnumerable<CodeArtifact> GenerateTypes()
         {
+            if (RootObject is JsonSchema jsonSchema)
+                _resolver.RegisterSchemaDefinitions(jsonSchema.Definitions);
+
             var types = base.GenerateTypes();
             var extraTypes = new List<CodeArtifact>();
 

--- a/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -37,6 +37,9 @@ namespace Bonsai.Sgen
 
         protected override CodeArtifact GenerateType(JsonSchema schema, string typeNameHint)
         {
+            if (schema.TryGetExternalTypeName(out var _))
+                return new CodeArtifact(typeNameHint, default, default, default, string.Empty);
+
             var typeName = _resolver.GetOrGenerateTypeName(schema, typeNameHint);
             if (schema.IsEnumeration)
             {
@@ -136,7 +139,10 @@ namespace Bonsai.Sgen
                 extraTypes.Add(GenerateClass(deserializer));
             }
 
-            return types.Select(ReplaceInitOnlyProperties).Concat(extraTypes);
+            return types
+                .Where(type => type.Type != CodeArtifactType.Undefined)
+                .Select(ReplaceInitOnlyProperties)
+                .Concat(extraTypes);
         }
     }
 }

--- a/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -114,14 +114,14 @@ namespace Bonsai.Sgen
                 var matchTemplate = new CSharpTypeMatchTemplate(type, _provider, _options, Settings);
                 extraTypes.Add(GenerateClass(matchTemplate));
             }
-            if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson))
+            if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson) && classTypes.Count > 0)
             {
                 var serializer = new CSharpJsonSerializerTemplate(classTypes, _provider, _options, Settings);
                 var deserializer = new CSharpJsonDeserializerTemplate(schema, classTypes, _provider, _options, Settings);
                 extraTypes.Add(GenerateClass(serializer));
                 extraTypes.Add(GenerateClass(deserializer));
             }
-            if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.YamlDotNet))
+            if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.YamlDotNet) && classTypes.Count > 0)
             {
                 if (discriminatorTypes.Count > 0)
                 {

--- a/Bonsai.Sgen/CSharpSerializerTemplate.cs
+++ b/Bonsai.Sgen/CSharpSerializerTemplate.cs
@@ -75,10 +75,14 @@ namespace Bonsai.Sgen
                             new CodeTypeReference(modelType.TypeName))))));
             }
 
+            var defaultType = _schema.Title;
+            if (string.IsNullOrEmpty(defaultType))
+                defaultType = ModelTypes.FirstOrDefault()?.TypeName;
+
             type.Members.Add(new CodeSnippetTypeMember(
 @$"    public {TypeName}()
     {{
-        Type = new Bonsai.Expressions.TypeMapping<{_schema.Title}>();
+        Type = new Bonsai.Expressions.TypeMapping<{defaultType}>();
     }}
 
     public Bonsai.Expressions.TypeMapping Type {{ get; set; }}

--- a/Bonsai.Sgen/CSharpTypeNameGenerator.cs
+++ b/Bonsai.Sgen/CSharpTypeNameGenerator.cs
@@ -9,5 +9,13 @@ namespace Bonsai.Sgen
             var defaultName = base.Generate(schema, typeNameHint);
             return CSharpNamingConvention.Instance.Apply(defaultName);
         }
+
+        public override string Generate(JsonSchema schema, string typeNameHint, IEnumerable<string> reservedTypeNames)
+        {
+            if (schema.TryGetExternalTypeName(out string typeName))
+                return typeName;
+
+            return base.Generate(schema, typeNameHint, reservedTypeNames);
+        }
     }
 }

--- a/Bonsai.Sgen/JsonSchemaExtensions.cs
+++ b/Bonsai.Sgen/JsonSchemaExtensions.cs
@@ -9,6 +9,21 @@ namespace Bonsai.Sgen
 {
     internal static class JsonSchemaExtensions
     {
+        public const string TypeNameAnnotation = "x-sgen-typename";
+
+        public static bool TryGetExternalTypeName(this JsonSchema schema, out string typeName)
+        {
+            if (schema.ExtensionData?.TryGetValue(TypeNameAnnotation, out object? value) is true &&
+                value is string annotationValue)
+            {
+                typeName = annotationValue;
+                return true;
+            }
+
+            typeName = string.Empty;
+            return false;
+        }
+
         public static JsonSchema WithCompatibleDefinitions(this JsonSchema schema, ITypeNameGenerator typeNameGenerator)
         {
             var schemaAppender = new JsonSchemaAppender(schema, typeNameGenerator);


### PR DESCRIPTION
A common impediment to reusing JSON schemas is the difficulty in scoping qualified type names across different schemas. To assist partially with this problem, we introduce a custom annotation `x-sgen-typename` which allows to fully qualify the name of a schema type.

When a schema type is indicated to be fully qualified, it is automatically considered external, and its definition is omitted from the generated code. The tests demonstrate an example of what a schema reuse infrastructure leveraging this custom annotation might look like.

Fixes #40 