### PR TITLE
Update target framework to .NET 8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/build/Common.props
+++ b/build/Common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/build/Version.props
+++ b/build/Version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Semantic version prefix -->
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' != 'true'">

--- a/src/Bonsai.Sgen.Tests/Bonsai.Sgen.Tests.csproj
+++ b/src/Bonsai.Sgen.Tests/Bonsai.Sgen.Tests.csproj
@@ -6,13 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net60" Version="1.4.5" />
-    <PackageReference Include="Bonsai.Core" Version="2.8.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.0" />
+    <PackageReference Include="Bonsai.Core" Version="2.8.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Sgen.Tests/CompilerTestHelper.cs
+++ b/src/Bonsai.Sgen.Tests/CompilerTestHelper.cs
@@ -22,7 +22,7 @@ namespace Bonsai.Sgen.Tests
                 typeof(Combinator).Assembly.Location
             };
             var assemblyReferences = serializerDependencies.Select(path => MetadataReference.CreateFromFile(path)).ToList();
-            assemblyReferences.AddRange(Net60.References.All);
+            assemblyReferences.AddRange(Net80.References.All);
 
             var compilation = CSharpCompilation.Create(
                 nameof(CompilerTestHelper),

--- a/src/Bonsai.Sgen/Bonsai.Sgen.csproj
+++ b/src/Bonsai.Sgen/Bonsai.Sgen.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NJsonSchema.CodeGeneration.CSharp" Version="10.9.0" />
     <PackageReference Include="NJsonSchema.Yaml" Version="10.9.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.CodeDom" Version="6.0.0" />
+    <PackageReference Include="System.CodeDom" Version="8.0.0" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
The project target framework is updated to .NET 8. This is the latest long-term support release and will help all CI workflows, as well as the upcoming documentation website generation, to leverage several improvements in this release.

The main required change other than package updates was to have the reference assemblies used in Roslyn-based unit testing to target .NET 8 as well.