### PR TITLE
Update generators to support latest YamlDotNet

### DIFF
--- a/src/Bonsai.Sgen/Bonsai.Sgen.csproj
+++ b/src/Bonsai.Sgen/Bonsai.Sgen.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NJsonSchema.Yaml" Version="10.9.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
-    <PackageReference Include="YamlDotNet" Version="13.7.1" />
+    <PackageReference Include="YamlDotNet" Version="16.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Bonsai.Sgen/CSharpNamingConvention.cs
+++ b/src/Bonsai.Sgen/CSharpNamingConvention.cs
@@ -17,5 +17,10 @@ namespace Bonsai.Sgen
             var prefix = result.StartsWith('_') ? "_" : string.Empty;
             return prefix + result.Replace("_", string.Empty);
         }
+
+        public string Reverse(string value)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/src/Bonsai.Sgen/CSharpYamlDiscriminatorTypeInspectorTemplate.cs
+++ b/src/Bonsai.Sgen/CSharpYamlDiscriminatorTypeInspectorTemplate.cs
@@ -19,7 +19,7 @@ namespace Bonsai.Sgen
         public override void BuildType(CodeTypeDeclaration type)
         {
             type.IsPartial = false;
-            type.BaseTypes.Add(typeof(TypeInspectorSkeleton));
+            type.BaseTypes.Add(typeof(ReflectionTypeInspector));
             type.Members.Add(new CodeSnippetTypeMember(
 @$"    readonly YamlDotNet.Serialization.ITypeInspector innerTypeDescriptor;
 
@@ -64,6 +64,11 @@ namespace Bonsai.Sgen
 
         public string Name {{ get; private set; }}
 
+        public bool Required
+        {{
+            get {{ return true; }}
+        }}
+
         public bool CanWrite
         {{
             get {{ return true; }}
@@ -75,6 +80,16 @@ namespace Bonsai.Sgen
         }}
 
         public System.Type TypeOverride {{ get; set; }}
+
+        public System.Type ConverterType
+        {{
+            get {{ return null; }}
+        }}
+
+        public bool AllowNulls
+        {{
+            get {{ return false; }}
+        }}
 
         public int Order {{ get; set; }}
 


### PR DESCRIPTION
The latest version of the YamlDotNet library has introduced breaking changes in interface contracts requiring extra properties to be implemented on custom type inspectors and property descriptors used to implement discriminators for polymorphic class hierarchies.

To make generated code compatible with these changes, which will become mandatory in the upcoming release of the Bonsai editor, we introduce in this PR required modifications to the generated code when targeting YAML serializers.

In general, the changes are actually backwards compatible even in cases where using an old YamlDotNet version, since adding additional properties to classes is non-breaking. The one exception is the [`ReflectionTypeInspector`](https://github.com/aaubry/YamlDotNet/blob/a59301b38b39adc087f55b2d58abe56e34769979/YamlDotNet/Serialization/TypeInspectors/ReflectionTypeInspector.cs) class, which was introduced in YamlDotNet v16 as a base class to avoid having to provide default implementations for `ITypeInspector.GetEnumName` and `ITypeInspector.GetEnumValue`.

This shouldn't be problematic as soon as the update to YamlDotNet becomes widespread, but in case this ever becomes a problem later we could introduce a flag requesting emitting legacy YamlDotNet compatible code by using [`TypeInspectorSkeleton`](https://github.com/aaubry/YamlDotNet/blob/a59301b38b39adc087f55b2d58abe56e34769979/YamlDotNet/Serialization/TypeInspectors/TypeInspectorSkeleton.cs) as the base type instead.