### PR TITLE
Fix property name format in PrintMembers

### DIFF
--- a/src/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/src/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -273,7 +273,7 @@ namespace Bonsai.Sgen
                         stringBuilderVariable,
                         AppendMethodName,
                         new CodeSnippetExpression(
-                            $"\"{property.Name} = \" + {property.FieldName}" +
+                            $"\"{property.PropertyName} = \" + {property.FieldName}" +
                             (++propertyIndex < propertyCount ? " + \", \"" : string.Empty))));
                 }
                 printMembersMethod.Statements.Add(new CodeMethodReturnStatement(new CodePrimitiveExpression(propertyCount > 0)));


### PR DESCRIPTION
`PropertyName` contains the correctly cased name of the generated public property and should be the one included in `PrintMembers`.

Fixes #52 