### PR TITLE
Use generic dictionary as property type

### DIFF
--- a/src/Bonsai.Sgen/CSharpCodeDomGeneratorSettings.cs
+++ b/src/Bonsai.Sgen/CSharpCodeDomGeneratorSettings.cs
@@ -15,6 +15,9 @@ namespace Bonsai.Sgen
             ArrayInstanceType = "System.Collections.Generic.List";
             ArrayBaseType = "System.Collections.Generic.List";
             ArrayType = "System.Collections.Generic.List";
+            DictionaryInstanceType = "System.Collections.Generic.Dictionary";
+            DictionaryBaseType = "System.Collections.Generic.Dictionary";
+            DictionaryType = "System.Collections.Generic.Dictionary";
         }
 
         public SerializerLibraries SerializerLibraries { get; set; }


### PR DESCRIPTION
This is similar to the case for JSON arrays and allows correct code generation.

Fixes #69 