### PR TITLE
Infer namespace from path and type name from title

### DIFF
--- a/src/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/src/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -237,7 +237,7 @@ namespace Bonsai.Sgen
                         "Source"))));
                 type.CustomAttributes.Add(new CodeAttributeDeclaration(
                     new CodeTypeReference("Bonsai.CombinatorAttribute"),
-                    new CodeAttributeArgument(new CodePrimitiveExpression(CombinatorMethodName))));
+                    new CodeAttributeArgument("MethodName", new CodePrimitiveExpression(CombinatorMethodName))));
             }
 
             const string PrintMembersMethodName = "PrintMembers";

--- a/src/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/src/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -33,6 +33,8 @@ namespace Bonsai.Sgen
             Settings = settings;
         }
 
+        public CSharpTypeResolver Resolver => _resolver;
+
         public new CSharpCodeDomGeneratorSettings Settings { get; }
 
         protected override CodeArtifact GenerateType(JsonSchema schema, string typeNameHint)

--- a/src/Bonsai.Sgen/CSharpSerializerTemplate.cs
+++ b/src/Bonsai.Sgen/CSharpSerializerTemplate.cs
@@ -3,7 +3,6 @@ using System.CodeDom.Compiler;
 using System.ComponentModel;
 using System.Xml.Serialization;
 using NJsonSchema;
-using NJsonSchema.CodeGeneration;
 
 namespace Bonsai.Sgen
 {

--- a/src/Bonsai.Sgen/CSharpTypeNameGenerator.cs
+++ b/src/Bonsai.Sgen/CSharpTypeNameGenerator.cs
@@ -17,5 +17,13 @@ namespace Bonsai.Sgen
 
             return base.Generate(schema, typeNameHint, reservedTypeNames);
         }
+
+        public string GenerateNamespace(JsonSchema schema, string namespaceNameHint)
+        {
+            const char NamespaceSeparator = '.';
+            var parts = namespaceNameHint.Split(NamespaceSeparator, StringSplitOptions.RemoveEmptyEntries);
+            var partIdentifiers = Array.ConvertAll(parts, part => Generate(schema, part));
+            return string.Join(NamespaceSeparator, partIdentifiers);
+        }
     }
 }

--- a/src/Bonsai.Sgen/Program.cs
+++ b/src/Bonsai.Sgen/Program.cs
@@ -89,27 +89,24 @@ namespace Bonsai.Sgen
                 var generator = new CSharpCodeDomGenerator(schema, settings);
 
                 var generatorTypeName = parseResult.GetValue(generatorTypeNameOption);
-                if (string.IsNullOrEmpty(generatorTypeName))
+                if (string.IsNullOrEmpty(generatorTypeName) && schema.HasTypeNameTitle)
                 {
-                    generatorTypeName = generator.Resolver.Resolve(schema, false, schema.Title);
-                    if (nameGenerator.ReservedTypeNames.Contains(generatorTypeName))
-                        generatorTypeName =
-                            schema.HasTypeNameTitle ? schema.Title :
-                            schemaPath is not null ? Path.GetFileNameWithoutExtension(schemaPath.Name) :
-                            "DataSchema";
+                    generatorTypeName = schema.Title;
                 }
 
-                generatorTypeName = nameGenerator.Generate(schema, generatorTypeName, nameGenerator.ReservedTypeNames);
                 var generatorNamespace = parseResult.GetValue(generatorNamespaceOption);
                 if (string.IsNullOrEmpty(generatorNamespace))
-                    generatorNamespace = generatorTypeName;
+                    generatorNamespace =
+                        schemaPath is not null ? Path.GetFileNameWithoutExtension(schemaPath.Name) :
+                        !string.IsNullOrEmpty(schema.Title) ? schema.Title :
+                        "DataSchema";
 
-                settings.Namespace = generatorNamespace;
+                settings.Namespace = nameGenerator.GenerateNamespace(schema, generatorNamespace);
                 var code = generator.GenerateFile(generatorTypeName);
 
                 var outputFilePath = parseResult.GetValue(nameOption);
                 if (string.IsNullOrEmpty(outputFilePath))
-                    outputFilePath = $"{generatorNamespace}.Generated.cs";
+                    outputFilePath = $"{settings.Namespace}.Generated.cs";
 
                 var outputPath = parseResult.GetValue(outputPathOption);
                 if (!string.IsNullOrEmpty(outputPath))

--- a/src/Bonsai.Sgen/Program.cs
+++ b/src/Bonsai.Sgen/Program.cs
@@ -27,9 +27,15 @@ namespace Bonsai.Sgen
                               "of the JSON schema will be used, if available."
             };
 
-            var outputPathOption = new Option<string>("--output")
+            var outputPathOption = new Option<string>("--output", "-o")
             {
-                Description = "Specifies the name of the file containing the generated code."
+                Description = "Location to place the generated output. The default is the current directory."
+            };
+
+            var nameOption = new Option<string>("--name", "-n")
+            {
+                Description = "Name of the generated output file. If no name is specified, the type name hint " +
+                              "of the root element type will be used, if available."
             };
 
             var serializerLibrariesOption = new Option<SerializerLibraries>("--serializer")
@@ -54,6 +60,7 @@ namespace Bonsai.Sgen
             rootCommand.Options.Add(generatorNamespaceOption);
             rootCommand.Options.Add(generatorTypeNameOption);
             rootCommand.Options.Add(outputPathOption);
+            rootCommand.Options.Add(nameOption);
             rootCommand.Options.Add(serializerLibrariesOption);
             rootCommand.SetAction(async (parseResult, cancellationToken) =>
             {
@@ -100,12 +107,18 @@ namespace Bonsai.Sgen
                 settings.Namespace = generatorNamespace;
                 var code = generator.GenerateFile(generatorTypeName);
 
-                var outputFilePath = parseResult.GetValue(outputPathOption);
+                var outputFilePath = parseResult.GetValue(nameOption);
                 if (string.IsNullOrEmpty(outputFilePath))
-                {
                     outputFilePath = $"{generatorNamespace}.Generated.cs";
+
+                var outputPath = parseResult.GetValue(outputPathOption);
+                if (!string.IsNullOrEmpty(outputPath))
+                {
+                    Directory.CreateDirectory(outputPath);
+                    outputFilePath = Path.Combine(outputPath, outputFilePath);
                 }
 
+                outputFilePath = Path.ChangeExtension(outputFilePath, ".cs");
                 Console.WriteLine($"Writing schema classes to {outputFilePath}...");
                 File.WriteAllText(outputFilePath, code);
             });


### PR DESCRIPTION
Each schema file must give rise to a distinct namespace due to commonly named operators. Since schema files are often unique and refer to a fully closed set of types, a reasonable default is to use their sanitized name as namespace by default.

The root type name hint will be taken exclusively from the schema title, or from titles in the actual root schema.

A new option `--name | -n` is added to allow explicitly naming the generated file. By default, the generated file name will match the sanitized namespace name.

Fixes #76 