### PR TITLE
Add shorthand serializer options

### DIFF
--- a/src/Bonsai.Sgen/CSharpCodeDomTemplate.cs
+++ b/src/Bonsai.Sgen/CSharpCodeDomTemplate.cs
@@ -38,6 +38,9 @@ namespace Bonsai.Sgen
 
         private string GetVersionString()
         {
+            if (Settings.SerializerLibraries == SerializerLibraries.None)
+                return $"{GeneratorAssemblyName.Version}";
+
             var serializerLibraries = new List<string>();
             if (Settings.SerializerLibraries.HasFlag(SerializerLibraries.NewtonsoftJson))
             {

--- a/src/Bonsai.Sgen/Program.cs
+++ b/src/Bonsai.Sgen/Program.cs
@@ -38,22 +38,21 @@ namespace Bonsai.Sgen
                               "of the root element type will be used, if available."
             };
 
-            var serializerLibrariesOption = new Option<SerializerLibraries>("--serializer")
+            var serializerLibrariesOption = new Option<SerializerOptions>("--serializer")
             {
                 Description = "Specifies the serializer data annotations to include in the generated classes.",
-                DefaultValueFactory = _ => SerializerLibraries.YamlDotNet,
                 AllowMultipleArgumentsPerToken = true,
                 Arity = ArgumentArity.OneOrMore,
                 CustomParser = result =>
                 {
-                    SerializerLibraries serializers = default;
+                    SerializerOptions serializers = default;
                     foreach (var token in result.Tokens)
                     {
-                        serializers |= (SerializerLibraries)Enum.Parse(typeof(SerializerLibraries), token.Value);
+                        serializers |= (SerializerOptions)Enum.Parse(typeof(SerializerOptions), token.Value);
                     }
                     return serializers;
                 }
-            }.AcceptOnlyFromAmong(typeof(SerializerLibraries).GetEnumNames());
+            }.AcceptOnlyFromAmong(typeof(SerializerOptions).GetEnumNames());
             
             var rootCommand = new RootCommand("Tool for automatically generating YML serialization classes from schema files.");
             rootCommand.Arguments.Add(schemaPathArgument);
@@ -82,7 +81,7 @@ namespace Bonsai.Sgen
 
                 var settings = new CSharpCodeDomGeneratorSettings();
                 var nameGenerator = (CSharpTypeNameGenerator)settings.TypeNameGenerator;
-                settings.SerializerLibraries = parseResult.GetValue(serializerLibrariesOption);
+                settings.SerializerLibraries = (SerializerLibraries)parseResult.GetValue(serializerLibrariesOption);
 
                 schema = schema.WithCompatibleDefinitions(nameGenerator)
                                .WithResolvedDiscriminatorInheritance();
@@ -123,5 +122,12 @@ namespace Bonsai.Sgen
             var parseResult = rootCommand.Parse(args);
             return await parseResult.InvokeAsync();
         }
+    }
+
+    [Flags]
+    enum SerializerOptions
+    {
+        json = SerializerLibraries.NewtonsoftJson,
+        yaml = SerializerLibraries.YamlDotNet
     }
 }

--- a/src/Bonsai.Sgen/SerializerLibraries.cs
+++ b/src/Bonsai.Sgen/SerializerLibraries.cs
@@ -5,6 +5,6 @@
     {
         None = 0x0,
         NewtonsoftJson = 0x1,
-        YamlDotNet = 0x4,
+        YamlDotNet = 0x4
     }
 }


### PR DESCRIPTION
To simplify usage we replace serializer options with shorthand flags for JSON and YAML formats. These will point to the appropriate serialization backend for each of the file formats.

The new default is also changed to indicate no serialization. This means the following combinations are now possible:
  - `dotnet bonsai.sgen schema.json` (no serializers)
  - `dotnet bonsai.sgen schema.json --serializer json` (JSON serializers)
  - `dotnet bonsai.sgen schema.json --serializer yaml` (YAML serializers)
  - `dotnet bonsai.sgen schema.json --serializer json yaml` (JSON and YAML serializers)