### PR TITLE
Ensure enum properties are XML serializable

### DIFF
--- a/src/Bonsai.Sgen.Tests/EnumGenerationTests.cs
+++ b/src/Bonsai.Sgen.Tests/EnumGenerationTests.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NJsonSchema;
 using NJsonSchema.Generation;
+using System.Xml.Serialization;
 
 namespace Bonsai.Sgen.Tests
 {
@@ -70,6 +71,15 @@ namespace Bonsai.Sgen.Tests
             var code = generator.GenerateFile();
             Assert.IsTrue(code.Contains("EnumMemberAttribute(Value=\"A\")"));
             Assert.IsTrue(code.Contains("YamlMemberAttribute(Alias=\"A\")"));
+        }
+
+        [TestMethod]
+        public void GenerateStringEnum_OmitXmlIgnoreAttributeInEnumProperties()
+        {
+            var schema = JsonSchema.FromType<Foo>();
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsFalse(code.Contains(nameof(XmlIgnoreAttribute)), $"Enum properties must omit {nameof(XmlIgnoreAttribute)}.");
         }
 
         [TestMethod]

--- a/src/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/src/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -122,7 +122,8 @@ namespace Bonsai.Sgen
                     }
                 };
 
-                if (!isPrimitive || property.Type == "object")
+                var xmlSerializable = isPrimitive || propertySchema?.ActualSchema.IsEnumeration is true;
+                if (!xmlSerializable || property.Type == "object")
                 {
                     propertyDeclaration.CustomAttributes.Add(new CodeAttributeDeclaration(
                         new CodeTypeReference(typeof(XmlIgnoreAttribute))));


### PR DESCRIPTION
Enum types should not be marked with `XmlIgnoreAttribute` to make it easier to work with constant properties in workflow operators.

Fixes #87 