### PR TITLE
Ensure duration properties are XML serializable

### DIFF
--- a/src/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
+++ b/src/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
@@ -6,6 +6,23 @@ namespace Bonsai.Sgen.Tests
     [TestClass]
     public class PropertyGenerationTests
     {
+        public class FooTimeSpan
+        {
+            public TimeSpan Bar { get; set; }
+
+            public TimeSpan? Baz { get; set; }
+        }
+
+        [TestMethod]
+        public void GenerateTimeSpanProperties_EnsureKnownTypesAndXmlSerialization()
+        {
+            var schema = JsonSchema.FromType<FooTimeSpan>();
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("public string BarXml"));
+            CompilerTestHelper.CompileFromSource(code);
+        }
+
         [TestMethod]
         public async Task GenerateFromRequiredNullableProperty_EnsurePropertyAnnotation()
         {


### PR DESCRIPTION
XML text conversion is implemented by using a hidden auxiliary field and the `XmlConvert` class to provide ISO8601 string conversion. Nullable property types are also supported by including relevant checks on conversion.

Basic regression tests are added to ensure valid build of generated code.