### PR TITLE
Ensure date-time properties are XML serializable

### DIFF
--- a/src/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
+++ b/src/Bonsai.Sgen.Tests/PropertyGenerationTests.cs
@@ -13,10 +13,27 @@ namespace Bonsai.Sgen.Tests
             public TimeSpan? Baz { get; set; }
         }
 
+        public class FooDateTime
+        {
+            public DateTimeOffset Bar { get; set; }
+
+            public DateTimeOffset? Baz { get; set; }
+        }
+
         [TestMethod]
         public void GenerateTimeSpanProperties_EnsureKnownTypesAndXmlSerialization()
         {
             var schema = JsonSchema.FromType<FooTimeSpan>();
+            var generator = TestHelper.CreateGenerator(schema);
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("public string BarXml"));
+            CompilerTestHelper.CompileFromSource(code);
+        }
+
+        [TestMethod]
+        public void GenerateDateTimeProperties_EnsureKnownTypesAndXmlSerialization()
+        {
+            var schema = JsonSchema.FromType<FooDateTime>();
             var generator = TestHelper.CreateGenerator(schema);
             var code = generator.GenerateFile();
             Assert.IsTrue(code.Contains("public string BarXml"));


### PR DESCRIPTION
XML text conversion is implemented by using a hidden auxiliary field and the `DateTimeOffset` round-trip string conversion and parsing to provide support for ISO8601 format. Nullable property types are also supported by including relevant checks on conversion.

Basic regression tests are added to ensure valid build of generated code.