### PR TITLE
Ensure nullable enum types are XML serializable

### DIFF
--- a/src/Bonsai.Sgen.Tests/EnumGenerationTests.cs
+++ b/src/Bonsai.Sgen.Tests/EnumGenerationTests.cs
@@ -14,6 +14,8 @@ namespace Bonsai.Sgen.Tests
         {
             public Bar Bar { get; set; }
 
+            public Bar? Baz { get; set; }
+
             [JsonConverter(typeof(StringEnumConverter))]
             public Bar Bar2 { get; set; }
         }

--- a/src/Bonsai.Sgen/CSharpClassTemplate.cs
+++ b/src/Bonsai.Sgen/CSharpClassTemplate.cs
@@ -122,7 +122,7 @@ namespace Bonsai.Sgen
                     }
                 };
 
-                var xmlSerializable = isPrimitive || propertySchema?.ActualSchema.IsEnumeration is true;
+                var xmlSerializable = isPrimitive || propertySchema?.ActualTypeSchema.IsEnumeration is true;
                 if (!xmlSerializable || property.Type == "object")
                 {
                     propertyDeclaration.CustomAttributes.Add(new CodeAttributeDeclaration(


### PR DESCRIPTION
The actual type schema must be used for testing to allow unwrapping nullable types.