### PR TITLE
Implement flag to skip external type generation

### DIFF
--- a/src/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
+++ b/src/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
@@ -124,7 +124,7 @@ schema => new TestJsonReferenceResolver(
         }
 
         [TestMethod]
-        public async Task GenerateWithExternalTypeReferenceProperty_SkipTypenameGen_EmitExternalTypeDefinition()
+        public async Task GenerateWithExternalTypeReferencePropertyAndGenerateExternalTypes_EmitExternalTypeDefinition()
         {
             var schemaA = await CreateCommonDefinitions();
             var generatorA = TestHelper.CreateGenerator(schemaA, schemaNamespace: $"{nameof(TestHelper)}.Base");
@@ -154,9 +154,9 @@ schema => new TestJsonReferenceResolver(
                 schemaA,
                 generatorA.Settings.Namespace));
 
-            var generatorB = TestHelper.CreateGenerator(schemaB, schemaNamespace: $"{nameof(TestHelper)}.Derived", skipExternalTypeNames: true);
+            var generatorB = TestHelper.CreateGenerator(schemaB, schemaNamespace: $"{nameof(TestHelper)}.Derived", generateExternalTypes: true);
             var codeB = generatorB.GenerateFile();
-            Assert.IsTrue(codeB.Contains("public partial class CommonType"), "External type should be emitted when skip flag is set.");
+            Assert.IsTrue(codeB.Contains("public partial class CommonType"), "Missing external type definition.");
         }
     }
 }

--- a/src/Bonsai.Sgen.Tests/TestHelper.cs
+++ b/src/Bonsai.Sgen.Tests/TestHelper.cs
@@ -8,15 +8,16 @@ namespace Bonsai.Sgen.Tests
             JsonSchema schema,
             SerializerLibraries serializerLibraries = SerializerLibraries.YamlDotNet | SerializerLibraries.NewtonsoftJson,
             string schemaNamespace = nameof(TestHelper),
-            bool skipExternalTypeNames = false)
+            bool generateExternalTypes = false)
         {
             var settings = new CSharpCodeDomGeneratorSettings
             {
                 Namespace = schemaNamespace,
-                SerializerLibraries = serializerLibraries,
-                SkipExternalTypeNames = skipExternalTypeNames
+                SerializerLibraries = serializerLibraries
             };
-            schema = schema.WithCompatibleDefinitions(settings.TypeNameGenerator)
+            var nameGenerator = (CSharpTypeNameGenerator)settings.TypeNameGenerator;
+            nameGenerator.GenerateExternalTypes = generateExternalTypes;
+            schema = schema.WithCompatibleDefinitions(nameGenerator)
                            .WithResolvedAnyOfNullableProperty()
                            .WithResolvedDiscriminatorInheritance();
 

--- a/src/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/src/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -39,7 +39,7 @@ namespace Bonsai.Sgen
 
         protected override CodeArtifact GenerateType(JsonSchema schema, string typeNameHint)
         {
-            if (!Settings.SkipExternalTypeNames && schema.TryGetExternalTypeName(out var _))
+            if (!Settings.GenerateExternalTypes && schema.TryGetExternalTypeName(out var _))
                 return new CodeArtifact(typeNameHint, default, default, default, string.Empty);
 
             var typeName = _resolver.GetOrGenerateTypeName(schema, typeNameHint);

--- a/src/Bonsai.Sgen/CSharpCodeDomGeneratorSettings.cs
+++ b/src/Bonsai.Sgen/CSharpCodeDomGeneratorSettings.cs
@@ -23,11 +23,8 @@ namespace Bonsai.Sgen
 
         public SerializerLibraries SerializerLibraries { get; set; }
 
-        public bool SkipExternalTypeNames
-        {
-            // TODO What to do here if a different implementation of the interface is passed?
-            get => ((CSharpTypeNameGenerator)TypeNameGenerator).SkipExternalTypeNames;
-            set => ((CSharpTypeNameGenerator)TypeNameGenerator).SkipExternalTypeNames = value;
-        }
+        public bool GenerateExternalTypes =>
+            TypeNameGenerator is CSharpTypeNameGenerator nameGenerator &&
+            nameGenerator.GenerateExternalTypes;
     }
 }

--- a/src/Bonsai.Sgen/CSharpTypeNameGenerator.cs
+++ b/src/Bonsai.Sgen/CSharpTypeNameGenerator.cs
@@ -4,7 +4,7 @@ namespace Bonsai.Sgen
 {
     internal class CSharpTypeNameGenerator : DefaultTypeNameGenerator
     {
-        public bool SkipExternalTypeNames { get; set; }
+        public bool GenerateExternalTypes { get; set; }
 
         protected override string Generate(JsonSchema schema, string typeNameHint)
         {
@@ -14,7 +14,7 @@ namespace Bonsai.Sgen
 
         public override string Generate(JsonSchema schema, string typeNameHint, IEnumerable<string> reservedTypeNames)
         {
-            if (!SkipExternalTypeNames && schema.TryGetExternalTypeName(out string typeName))
+            if (!GenerateExternalTypes && schema.TryGetExternalTypeName(out string typeName))
                 return typeName;
 
             return base.Generate(schema, typeNameHint, reservedTypeNames);

--- a/src/Bonsai.Sgen/Program.cs
+++ b/src/Bonsai.Sgen/Program.cs
@@ -53,9 +53,9 @@ namespace Bonsai.Sgen
                 }
             }.AcceptOnlyFromAmong(typeof(SerializerOptions).GetEnumNames());
 
-            var skipTypenameGenOption = new Option<bool>("--skip-typename-gen")
+            var generateExternalTypesOption = new Option<bool>("--generate-external-types")
             {
-                Description = "When set, ignores the x-sgen-typename json-schema extension and generates all types regardless of external type name annotations."
+                Description = "Specifies whether to generate serialization classes for types annotated with x-sgen-typename."
             };
 
             var rootCommand = new RootCommand("Tool for automatically generating serialization classes from JSON Schema files.");
@@ -65,7 +65,7 @@ namespace Bonsai.Sgen
             rootCommand.Options.Add(outputPathOption);
             rootCommand.Options.Add(nameOption);
             rootCommand.Options.Add(serializerLibrariesOption);
-            rootCommand.Options.Add(skipTypenameGenOption);
+            rootCommand.Options.Add(generateExternalTypesOption);
             rootCommand.SetAction(async (parseResult, cancellationToken) =>
             {
                 JsonSchema schema;
@@ -85,7 +85,7 @@ namespace Bonsai.Sgen
                 var settings = new CSharpCodeDomGeneratorSettings();
                 var nameGenerator = (CSharpTypeNameGenerator)settings.TypeNameGenerator;
                 settings.SerializerLibraries = (SerializerLibraries)parseResult.GetValue(serializerLibrariesOption);
-                settings.SkipExternalTypeNames = parseResult.GetValue(skipTypenameGenOption);
+                nameGenerator.GenerateExternalTypes = parseResult.GetValue(generateExternalTypesOption);
 
                 schema = schema.WithCompatibleDefinitions(nameGenerator)
                                .WithResolvedAnyOfNullableProperty()


### PR DESCRIPTION
This PR adds a new flag (`--skip-typename-gen`) that allows users to bypass the generation of references to external types via the previously implemented `x-sgen-typename` json-schema extension. While by default, we will want to generate "as reference", an obvious exception is the generation of the source package that implements the types to be referenced and, very likely, their partial business logic implementation too.

Closes #107 
