### PR TITLE
Emit definitions for internal type names

### DIFF
--- a/src/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
+++ b/src/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
@@ -122,5 +122,40 @@ schema => new TestJsonReferenceResolver(
             Assert.IsTrue(codeB.Contains("class DerivedType : TestHelper.Base.CommonType"), "Incorrect type declaration.");
             CompilerTestHelper.CompileFromSource(codeA, codeB);
         }
+
+        [TestMethod]
+        public async Task GenerateWithInternalTypeReference_EmitInternalTypeDefinition()
+        {
+            var schemaNamespace = $"{nameof(TestHelper)}.Derived";
+            var schemaA = await CreateCommonDefinitions();
+            var schemaB = await JsonSchema.FromJsonAsync(@"
+{
+    ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+    ""definitions"": {
+      ""SpecificType"": {
+        ""type"": ""object"",
+        ""properties"": {
+          ""Bar"": {
+            ""$ref"": ""https://schemaA/definitions/CommonType""
+          },
+          ""Baz"": {
+            ""type"": ""integer""
+          }
+        }
+      }
+    }
+  }
+",
+            documentPath: "",
+            schema => new TestJsonReferenceResolver(
+                new JsonSchemaAppender(schema, new DefaultTypeNameGenerator()),
+                schemaA,
+                schemaNamespace));
+
+            var generatorB = TestHelper.CreateGenerator(schemaB, schemaNamespace: schemaNamespace);
+            var codeB = generatorB.GenerateFile();
+            Assert.IsTrue(codeB.Contains("public partial class CommonType"), "Missing internal type definition.");
+            CompilerTestHelper.CompileFromSource(codeB);
+        }
     }
 }

--- a/src/Bonsai.Sgen/CSharpCodeDomGenerator.cs
+++ b/src/Bonsai.Sgen/CSharpCodeDomGenerator.cs
@@ -39,10 +39,10 @@ namespace Bonsai.Sgen
 
         protected override CodeArtifact GenerateType(JsonSchema schema, string typeNameHint)
         {
-            if (schema.TryGetExternalTypeName(out var _))
+            if (schema.TryGetExternalTypeName(out var typeName) && !CSharpTypeNameGenerator.NamespaceEquals(typeName, Settings.Namespace))
                 return new CodeArtifact(typeNameHint, default, default, default, string.Empty);
 
-            var typeName = _resolver.GetOrGenerateTypeName(schema, typeNameHint);
+            typeName = _resolver.GetOrGenerateTypeName(schema, typeNameHint);
             if (schema.IsEnumeration)
             {
                 return GenerateEnum(schema, typeName);

--- a/src/Bonsai.Sgen/CSharpCodeDomGeneratorSettings.cs
+++ b/src/Bonsai.Sgen/CSharpCodeDomGeneratorSettings.cs
@@ -8,7 +8,7 @@ namespace Bonsai.Sgen
         {
             GenerateDataAnnotations = false;
             GenerateJsonMethods = true;
-            TypeNameGenerator = new CSharpTypeNameGenerator();
+            TypeNameGenerator = new CSharpTypeNameGenerator(this);
             EnumNameGenerator = new CSharpEnumNameGenerator();
             PropertyNameGenerator = new CSharpPropertyNameGenerator();
             ValueGenerator = new CSharpValueGenerator(this);

--- a/src/Bonsai.Sgen/CSharpTypeNameGenerator.cs
+++ b/src/Bonsai.Sgen/CSharpTypeNameGenerator.cs
@@ -1,9 +1,13 @@
 ﻿using NJsonSchema;
+using NJsonSchema.CodeGeneration.CSharp;
 
 namespace Bonsai.Sgen
 {
-    internal class CSharpTypeNameGenerator : DefaultTypeNameGenerator
+    internal class CSharpTypeNameGenerator(CSharpGeneratorSettings settings) : DefaultTypeNameGenerator
     {
+        const char NamespaceSeparator = '.';
+        readonly CSharpGeneratorSettings _settings = settings;
+
         protected override string Generate(JsonSchema schema, string typeNameHint)
         {
             var defaultName = base.Generate(schema, typeNameHint);
@@ -12,7 +16,7 @@ namespace Bonsai.Sgen
 
         public override string Generate(JsonSchema schema, string typeNameHint, IEnumerable<string> reservedTypeNames)
         {
-            if (schema.TryGetExternalTypeName(out string typeName))
+            if (schema.TryGetExternalTypeName(out string typeName) && !NamespaceEquals(typeName, _settings.Namespace))
                 return typeName;
 
             return base.Generate(schema, typeNameHint, reservedTypeNames);
@@ -20,10 +24,24 @@ namespace Bonsai.Sgen
 
         public string GenerateNamespace(JsonSchema schema, string namespaceNameHint)
         {
-            const char NamespaceSeparator = '.';
             var parts = namespaceNameHint.Split(NamespaceSeparator, StringSplitOptions.RemoveEmptyEntries);
             var partIdentifiers = Array.ConvertAll(parts, part => Generate(schema, part));
             return string.Join(NamespaceSeparator, partIdentifiers);
+        }
+
+        internal static ReadOnlySpan<char> GetNamespaceFromTypeName(string typeName)
+        {
+            ArgumentNullException.ThrowIfNull(typeName, nameof(typeName));
+            var typeNameSeparatorIndex = typeName.LastIndexOf(NamespaceSeparator);
+            if (typeNameSeparatorIndex <= 0)
+                return string.Empty;
+
+            return typeName.AsSpan(..typeNameSeparatorIndex);
+        }
+
+        internal static bool NamespaceEquals(string typeName, string ns)
+        {
+            return MemoryExtensions.Equals(GetNamespaceFromTypeName(typeName), ns, StringComparison.Ordinal);
         }
     }
 }


### PR DESCRIPTION
Type schemas declared with `x-sgen-typename` should be defined if they are internal to the generated namespace.

This allows the same annotated JSON schema to be used both for generating the implementation of a reusable extension, and as a reference in a downstream schema which contains `$ref` declarations to its types, as long as they are declared inside distinct namespaces.

Closes #107 