### PR TITLE
Ensure extension data is propagated for inline discriminator schemas

### DIFF
--- a/src/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
+++ b/src/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
@@ -162,11 +162,12 @@ schema => new TestJsonReferenceResolver(
         public void GenerateWithExternalDiscriminatorReferenceProperty_OmitExternalDiscriminatorDefinition()
         {
             var derivedSchemas = SchemaTestHelper.CreateDerivedSchemas("kind", "Dog", "Cat");
-            var discriminator = SchemaTestHelper.CreateDiscriminatorSchema("kind", derivedSchemas);
-            var definitions = derivedSchemas.Prepend(new("Animal", discriminator));
-            var schema = SchemaTestHelper.CreateContainerSchema(definitions);
-            schema.Properties.Add("Animal", new JsonSchemaProperty { Reference = discriminator });
-            foreach (var definition in definitions)
+            var discriminator = SchemaTestHelper.CreateDiscriminatorSchema<JsonSchemaProperty>("kind", derivedSchemas);
+            var schema = SchemaTestHelper.CreateContainerSchema(derivedSchemas);
+            schema.Properties.Add("Animal", discriminator);
+
+            var schemaProperty = schema.Properties.First();
+            foreach (var definition in derivedSchemas.Prepend(new(schemaProperty.Key, schemaProperty.Value)))
             {
                 definition.Value.ExtensionData ??= new Dictionary<string, object>();
                 definition.Value.ExtensionData[JsonSchemaExtensions.TypeNameAnnotation] = $"TestHelper.Base.{definition.Key}";

--- a/src/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
+++ b/src/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
@@ -157,5 +157,84 @@ schema => new TestJsonReferenceResolver(
             Assert.IsTrue(codeB.Contains("public partial class CommonType"), "Missing internal type definition.");
             CompilerTestHelper.CompileFromSource(codeB);
         }
+
+          [TestMethod]
+          public async Task GenerateWithExternalDiscriminatorReferenceProperty_OmitExternalDiscriminatorDefinition()
+          {
+              var schema = await JsonSchema.FromJsonAsync("""
+  {
+    "$defs": {
+      "Dog": {
+        "type": "object",
+        "title": "Dog",
+        "x-sgen-typename": "TestHelper.Base.Dog",
+        "properties": {
+          "kind": {
+            "const": "Dog",
+            "type": "string"
+          }
+        }
+      },
+      "Cat": {
+        "type": "object",
+        "title": "Cat",
+        "x-sgen-typename": "TestHelper.Base.Cat",
+        "properties": {
+          "kind": {
+            "const": "Cat",
+            "type": "string"
+          }
+        }
+      },
+      "Animal": {
+        "title": "Animal",
+        "x-sgen-typename": "TestHelper.Base.Animal",
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "Dog": "#/$defs/Dog",
+            "Cat": "#/$defs/Cat"
+          }
+        },
+        "oneOf": [
+          { "$ref": "#/$defs/Dog" },
+          { "$ref": "#/$defs/Cat" }
+        ]
+      },
+      "Container": {
+        "type": "object",
+        "title": "Container",
+        "properties": {
+          "Animal": {
+            "$ref": "#/$defs/Animal"
+          }
+        }
+      }
+    }
+  }
+  """);
+            var generator = TestHelper.CreateGenerator(schema, schemaNamespace: nameof(TestHelper) + ".Derived");
+            var code = generator.GenerateFile();
+            Assert.IsTrue(code.Contains("public TestHelper.Base.Animal Animal"), "Container must reference external type.");
+            Assert.IsTrue(!code.Contains("public partial class Animal"), "External discriminator base type should not be generated.");
+
+            const string externalCode = @"
+      namespace TestHelper.Base
+      {
+        public class Animal
+        {
+        }
+
+        public class Dog : Animal
+        {
+        }
+
+        public class Cat : Animal
+        {
+        }
+      }
+      ";
+            CompilerTestHelper.CompileFromSource(externalCode, code);
+          }
     }
 }

--- a/src/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
+++ b/src/Bonsai.Sgen.Tests/ExternalTypeGenerationTests.cs
@@ -158,83 +158,34 @@ schema => new TestJsonReferenceResolver(
             CompilerTestHelper.CompileFromSource(codeB);
         }
 
-          [TestMethod]
-          public async Task GenerateWithExternalDiscriminatorReferenceProperty_OmitExternalDiscriminatorDefinition()
-          {
-              var schema = await JsonSchema.FromJsonAsync("""
-  {
-    "$defs": {
-      "Dog": {
-        "type": "object",
-        "title": "Dog",
-        "x-sgen-typename": "TestHelper.Base.Dog",
-        "properties": {
-          "kind": {
-            "const": "Dog",
-            "type": "string"
-          }
-        }
-      },
-      "Cat": {
-        "type": "object",
-        "title": "Cat",
-        "x-sgen-typename": "TestHelper.Base.Cat",
-        "properties": {
-          "kind": {
-            "const": "Cat",
-            "type": "string"
-          }
-        }
-      },
-      "Animal": {
-        "title": "Animal",
-        "x-sgen-typename": "TestHelper.Base.Animal",
-        "discriminator": {
-          "propertyName": "kind",
-          "mapping": {
-            "Dog": "#/$defs/Dog",
-            "Cat": "#/$defs/Cat"
-          }
-        },
-        "oneOf": [
-          { "$ref": "#/$defs/Dog" },
-          { "$ref": "#/$defs/Cat" }
-        ]
-      },
-      "Container": {
-        "type": "object",
-        "title": "Container",
-        "properties": {
-          "Animal": {
-            "$ref": "#/$defs/Animal"
-          }
-        }
-      }
-    }
-  }
-  """);
+        [TestMethod]
+        public void GenerateWithExternalDiscriminatorReferenceProperty_OmitExternalDiscriminatorDefinition()
+        {
+            var derivedSchemas = SchemaTestHelper.CreateDerivedSchemas("kind", "Dog", "Cat");
+            var discriminator = SchemaTestHelper.CreateDiscriminatorSchema("kind", derivedSchemas);
+            var definitions = derivedSchemas.Prepend(new("Animal", discriminator));
+            var schema = SchemaTestHelper.CreateContainerSchema(definitions);
+            schema.Properties.Add("Animal", new JsonSchemaProperty { Reference = discriminator });
+            foreach (var definition in definitions)
+            {
+                definition.Value.ExtensionData ??= new Dictionary<string, object>();
+                definition.Value.ExtensionData[JsonSchemaExtensions.TypeNameAnnotation] = $"TestHelper.Base.{definition.Key}";
+            }
+
             var generator = TestHelper.CreateGenerator(schema, schemaNamespace: nameof(TestHelper) + ".Derived");
             var code = generator.GenerateFile();
             Assert.IsTrue(code.Contains("public TestHelper.Base.Animal Animal"), "Container must reference external type.");
             Assert.IsTrue(!code.Contains("public partial class Animal"), "External discriminator base type should not be generated.");
 
             const string externalCode = @"
-      namespace TestHelper.Base
-      {
-        public class Animal
-        {
-        }
-
-        public class Dog : Animal
-        {
-        }
-
-        public class Cat : Animal
-        {
-        }
-      }
-      ";
+            namespace TestHelper.Base
+            {
+                public class Animal { }
+                public class Dog : Animal { }
+                public class Cat : Animal { }
+            }
+            ";
             CompilerTestHelper.CompileFromSource(externalCode, code);
-          }
+        }
     }
 }

--- a/src/Bonsai.Sgen/JsonSchemaExtensions.cs
+++ b/src/Bonsai.Sgen/JsonSchemaExtensions.cs
@@ -98,6 +98,10 @@ namespace Bonsai.Sgen
                             discriminatorSchema = new JsonSchema();
                             discriminatorSchema.DiscriminatorObject = actualSchema.DiscriminatorObject;
                             discriminatorSchema.IsAbstract = actualSchema.IsAbstract;
+                            if (actualSchema.ExtensionData?.Count > 0)
+                            {
+                                discriminatorSchema.ExtensionData = new Dictionary<string, object>(actualSchema.ExtensionData);
+                            }
                             RootObject.Definitions.Add(typeNameHint, discriminatorSchema);
                             ResolveOneOfInheritance(actualSchema, discriminatorSchema);
                         }


### PR DESCRIPTION
Closes #111 

@glopesdev This fixes my issue, but I wonder if there is a more principled way to propagate everything without going 1-by-1. I noticed that other fields (e.g: Title) also seem to be dropped during this process.